### PR TITLE
[DO NOT SUBMIT] A workaround proposal for address problem

### DIFF
--- a/cmd/fryd/genaccounts.go
+++ b/cmd/fryd/genaccounts.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hdac-io/friday/server"
 	eltypes "github.com/hdac-io/friday/x/executionlayer/types"
 	"github.com/hdac-io/friday/x/genutil"
+
+	sdk "github.com/hdac-io/friday/types"
 )
 
 const (
@@ -36,9 +38,10 @@ the base64 encoded publickey and a list of initial coins.`,
 			balance := args[1]
 			bondedAmount := args[2]
 
+			parsedPubKey, err := sdk.AccAddressFromBech32(publicKey)
 			// create concrete account type based on input parameters
 			account := eltypes.Account{
-				PublicKey:           publicKey,
+				PublicKey:           parsedPubKey,
 				InitialBalance:      balance,
 				InitialBondedAmount: bondedAmount,
 			}

--- a/x/executionlayer/client/cli/query.go
+++ b/x/executionlayer/client/cli/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hdac-io/friday/client"
 	"github.com/hdac-io/friday/client/context"
 	"github.com/hdac-io/friday/codec"
+	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/x/executionlayer/types"
 
 	"github.com/spf13/cobra"
@@ -37,7 +38,11 @@ func GetCmdQueryBalance(cdc *codec.Codec) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			name := args[0]
+			name, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				fmt.Printf("could not resolve address - %s \n", name)
+				return nil
+			}
 
 			queryData := types.QueryGetBalance{
 				Address: name,
@@ -65,7 +70,11 @@ func GetCmdQueryBalanceWithBlockHash(cdc *codec.Codec) *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			name := args[0]
+			name, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				fmt.Printf("could not resolve address - %s \n", name)
+				return nil
+			}
 			blockHash := []byte(args[1])
 
 			queryData := types.QueryGetBalanceDetail{

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -2,6 +2,7 @@ package executionlayer
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -135,8 +136,10 @@ func (k ExecutionLayerKeeper) GetQueryResultSimple(ctx sdk.Context,
 }
 
 // GetQueryBalanceResult queries with whole parameters
-func (k ExecutionLayerKeeper) GetQueryBalanceResult(ctx sdk.Context, stateHash []byte, address string) (string, error) {
-	res, err := grpc.QueryBlanace(k.client, stateHash, address, k.protocolVersion)
+func (k ExecutionLayerKeeper) GetQueryBalanceResult(ctx sdk.Context, stateHash []byte, address sdk.AccAddress) (string, error) {
+	appendedAddr := append(address.Bytes(), make([]byte, 12)...)
+	hexaddr := hex.EncodeToString(appendedAddr)
+	res, err := grpc.QueryBlanace(k.client, stateHash, hexaddr, k.protocolVersion)
 	if err != "" {
 		return "", fmt.Errorf(err)
 	}
@@ -145,9 +148,11 @@ func (k ExecutionLayerKeeper) GetQueryBalanceResult(ctx sdk.Context, stateHash [
 }
 
 // GetQueryBalanceResultSimple queries with whole parameters
-func (k ExecutionLayerKeeper) GetQueryBalanceResultSimple(ctx sdk.Context, address string) (string, error) {
+func (k ExecutionLayerKeeper) GetQueryBalanceResultSimple(ctx sdk.Context, address sdk.AccAddress) (string, error) {
+	appendedAddr := append(address.Bytes(), make([]byte, 12)...)
+	hexaddr := hex.EncodeToString(appendedAddr)
 	unitHash := k.GetUnitHashMap(ctx, ctx.BlockHeader().LastBlockId.Hash)
-	res, err := grpc.QueryBlanace(k.client, unitHash.EEState, address, k.protocolVersion)
+	res, err := grpc.QueryBlanace(k.client, unitHash.EEState, hexaddr, k.protocolVersion)
 	if err != "" {
 		return "", fmt.Errorf(err)
 	}

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc/transforms"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
+	sdk "github.com/hdac-io/friday/types"
 	"github.com/stretchr/testify/assert"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -44,7 +45,8 @@ func TestGetQueryResult(t *testing.T) {
 func TestGetQueryBalanceResult(t *testing.T) {
 	input := setupTestInput()
 	parentHash := genesis(input.elk)
-	res, err := input.elk.GetQueryBalanceResult(input.ctx, parentHash, input.genesisAddress)
+	addr, _ := sdk.AccAddressFromBech32(input.genesisAddress)
+	res, err := input.elk.GetQueryBalanceResult(input.ctx, parentHash, addr)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -81,7 +81,7 @@ func queryBalanceDetail(ctx sdk.Context, path []string, req abci.RequestQuery, k
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, err := keeper.GetQueryBalanceResult(ctx, param.StateHash, string(param.Address))
+	val, err := keeper.GetQueryBalanceResult(ctx, param.StateHash, param.Address)
 	if err != nil {
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, err.Error())
 	}

--- a/x/executionlayer/querier_test.go
+++ b/x/executionlayer/querier_test.go
@@ -49,10 +49,11 @@ func TestQueryEEDetail(t *testing.T) {
 func TestQueryBalanceDetail(t *testing.T) {
 	input, keeper, querier := setup()
 	parentHash := genesis(keeper)
+	genAddr, _ := sdk.AccAddressFromBech32(input.genesisAddress)
 
 	queryData := QueryGetBalanceDetail{
 		StateHash: parentHash,
-		Address:   input.genesisAddress,
+		Address:   genAddr,
 	}
 
 	bz, _ := input.cdc.MarshalJSON(queryData)

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -1,6 +1,7 @@
 package executionlayer
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"os"
@@ -44,7 +45,7 @@ func setupTestInput() testInput {
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id"}, false, log.NewNopLogger())
 
 	blockStateHash := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
-	genesisAddress := "d70243dd9d0d646fd6df282a8f7a8fa05a6629bec01d8024c3611eb1c1fb9f84"
+	genesisAddress := "friday15evpva2u57vv6l5czehyk69s0wnq9hrkqulwfz"
 	chainName := "hdac"
 	accounts := map[string][]string{
 		genesisAddress: []string{"500000000", "1000000"}}
@@ -80,8 +81,11 @@ func setupTestInput() testInput {
 func genesis(keeper ExecutionLayerKeeper) []byte {
 	input := setupTestInput()
 	fmt.Printf("%v", input.genesisAccount)
+	genaddr, _ := sdk.AccAddressFromBech32(input.genesisAddress)
+	appendedAddr := append(genaddr.Bytes(), make([]byte, 12)...)
+	hexaddr := hex.EncodeToString(appendedAddr)
 	genesisConfig, err := util.GenesisConfigMock(
-		input.chainName, input.genesisAddress,
+		input.chainName, hexaddr,
 		input.genesisAccount[input.genesisAddress][0], input.genesisAccount[input.genesisAddress][1],
 		input.elk.protocolVersion, input.costs, "./wasms/mint_install.wasm", "./wasms/pos_install.wasm")
 

--- a/x/executionlayer/types/genesis.go
+++ b/x/executionlayer/types/genesis.go
@@ -1,11 +1,13 @@
 package types
 
 import (
-	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
+
+	sdk "github.com/hdac-io/friday/types"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc"
@@ -35,9 +37,9 @@ type Genesis struct {
 // Account : Genesis Account Information.
 type Account struct {
 	// PublicKey : base64 encoded public key string
-	PublicKey           string `json:"public_key"`
-	InitialBalance      string `json:"initial_balance"`
-	InitialBondedAmount string `json:"initial_bonded_amount"`
+	PublicKey           sdk.AccAddress `json:"public_key"`
+	InitialBalance      string         `json:"initial_balance"`
+	InitialBondedAmount string         `json:"initial_bonded_amount"`
 }
 
 // WasmCosts : CasperLabs EE Wasm Cost table
@@ -100,11 +102,13 @@ func ToChainSpecGenesisConfig(config GenesisConf) (*ipc.ChainSpec_GenesisConfig,
 
 	mintWasm, err := ioutil.ReadFile(config.Genesis.MintCodePath)
 	if err != nil {
+		fmt.Println(err)
 		return nil, ErrInvalidWasmPath(DefaultCodespace, config.Genesis.MintCodePath)
 	}
 	posWasm, err := ioutil.ReadFile(config.Genesis.PosCodePath)
 	if err != nil {
-		return nil, ErrInvalidWasmPath(DefaultCodespace, config.Genesis.MintCodePath)
+		fmt.Println(err)
+		return nil, ErrInvalidWasmPath(DefaultCodespace, config.Genesis.PosCodePath)
 	}
 
 	var accounts []*ipc.ChainSpec_GenesisAccount
@@ -155,15 +159,15 @@ func toProtocolVersion(pvString string) (*state.ProtocolVersion, error) {
 }
 
 func toChainSpecGenesisAccount(account Account) (*ipc.ChainSpec_GenesisAccount, error) {
-	publicKey, err := base64.StdEncoding.DecodeString(account.PublicKey)
-	if err != nil || len(publicKey) != 32 {
-		return nil, ErrPublicKeyDecode(DefaultCodespace, account.PublicKey)
-	}
+	// publicKey, err := base64.StdEncoding.DecodeString(account.PublicKey)
+	// if err != nil || len(publicKey) != 32 {
+	// 	return nil, ErrPublicKeyDecode(DefaultCodespace, account.PublicKey)
+	// }
 	balance := toBigInt(account.InitialBalance)
 	bondedAmount := toBigInt(account.InitialBondedAmount)
 
 	genesisAccount := ipc.ChainSpec_GenesisAccount{}
-	genesisAccount.PublicKey = publicKey
+	genesisAccount.PublicKey = append(account.PublicKey.Bytes(), make([]byte, 12)...)
 	genesisAccount.Balance = &balance
 	genesisAccount.BondedAmount = &bondedAmount
 

--- a/x/executionlayer/types/genesis_test.go
+++ b/x/executionlayer/types/genesis_test.go
@@ -1,18 +1,18 @@
 package types
 
 import (
-	"encoding/base64"
 	"os"
 	"reflect"
 	"testing"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
+	sdk "github.com/hdac-io/friday/types"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	mintCodePath = "$HOME/.fryd/contracts/mint_install.wasm"
-	posCodePath  = "$HOME/.fryd/contracts/genesis/pos_install.wasm"
+	posCodePath  = "$HOME/.fryd/contracts/pos_install.wasm"
 )
 
 func TestToProtocolVersion(t *testing.T) {
@@ -47,21 +47,24 @@ func TestToProtocolVersion(t *testing.T) {
 
 func TestToChainSpecGenesisAccount(t *testing.T) {
 	// valid input
+	addr, _ := sdk.AccAddressFromBech32("friday15evpva2u57vv6l5czehyk69s0wnq9hrkqulwfz")
 	account := Account{
-		PublicKey:           "lGBOOzBXMuDEPxDIE5of4u9U+yzmnrB2MbjA0dQM9LQ=",
+		PublicKey:           addr,
 		InitialBalance:      "100000000",
 		InitialBondedAmount: "10000",
 	}
 	_, err := toChainSpecGenesisAccount(account)
 	require.Nil(t, err)
 
-	account.PublicKey = "invalid-public-key"
-	_, err = toChainSpecGenesisAccount(account)
-	require.NotNil(t, err)
+	// The reason of the blocked tests below: AccAddressFromBech32 type blocks malformed address
 
-	account.PublicKey = base64.StdEncoding.EncodeToString([]byte("invalid-public-key"))
-	_, err = toChainSpecGenesisAccount(account)
-	require.NotNil(t, err)
+	// account.PublicKey = "invalid-public-key"
+	// _, err = toChainSpecGenesisAccount(account)
+	// require.NotNil(t, err)
+
+	// account.PublicKey = base64.StdEncoding.EncodeToString([]byte("invalid-public-key"))
+	// _, err = toChainSpecGenesisAccount(account)
+	// require.NotNil(t, err)
 }
 
 func TestToChainSpecGenesisConfig(t *testing.T) {
@@ -94,18 +97,20 @@ func TestToChainSpecGenesisConfig(t *testing.T) {
 	// revert to valid input
 	genesisState.GenesisConf.Genesis.ProtocolVersion = "1.0.0"
 
-	// invalid account(not conformant to base64 encoded public key)
-	genesisState.GenesisConf.Genesis.Accounts = make([]Account, 1)
-	genesisState.GenesisConf.Genesis.Accounts[0] = Account{
-		PublicKey:           "invalid-public-key",
-		InitialBalance:      "100000000",
-		InitialBondedAmount: "10000",
-	}
-	_, err = ToChainSpecGenesisConfig(genesisState.GenesisConf)
-	require.NotNil(t, err)
+	// The reason of the blocked tests below: AccAddressFromBech32 type blocks malformed address
 
-	genesisState.GenesisConf.Genesis.Accounts[0].PublicKey =
-		base64.StdEncoding.EncodeToString([]byte("invalid-public-key"))
-	_, err = ToChainSpecGenesisConfig(genesisState.GenesisConf)
-	require.NotNil(t, err)
+	// invalid account(not conformant to base64 encoded public key)
+	// genesisState.GenesisConf.Genesis.Accounts = make([]Account, 1)
+	// genesisState.GenesisConf.Genesis.Accounts[0] = Account{
+	// 	PublicKey:           "invalid-public-key",
+	// 	InitialBalance:      "100000000",
+	// 	InitialBondedAmount: "10000",
+	// }
+	// _, err = ToChainSpecGenesisConfig(genesisState.GenesisConf)
+	// require.NotNil(t, err)
+
+	// genesisState.GenesisConf.Genesis.Accounts[0].PublicKey =
+	// 	base64.StdEncoding.EncodeToString([]byte("invalid-public-key"))
+	// _, err = ToChainSpecGenesisConfig(genesisState.GenesisConf)
+	// require.NotNil(t, err)
 }

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"fmt"
+
+	sdk "github.com/hdac-io/friday/types"
 )
 
 // QueryExecutionLayer payload for a EE query
@@ -32,22 +34,22 @@ func (q QueryExecutionLayer) String() string {
 // QueryGetBalanceDetail payload for balance query
 type QueryGetBalanceDetail struct {
 	StateHash []byte
-	Address   string
+	Address   sdk.AccAddress
 }
 
 // implement fmt.Stringer
 func (q QueryGetBalanceDetail) String() string {
-	return fmt.Sprintf("State: %s\nAddress: %s", q.StateHash, q.Address)
+	return fmt.Sprintf("State: %s\nAddress: %s", q.StateHash, q.Address.String())
 }
 
 // QueryGetBalance payload for balance query in the latest data
 type QueryGetBalance struct {
-	Address string
+	Address sdk.AccAddress
 }
 
 // implement fmt.Stringer
 func (q QueryGetBalance) String() string {
-	return fmt.Sprintf("Address: %s", q.Address)
+	return fmt.Sprintf("Address: %s", q.Address.String())
 }
 
 // QueryExecutionLayerResp is used for response of EE query

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -210,6 +210,7 @@ func createTestAddrs(numAddrs int) []sdk.AccAddress {
 	for i := 100; i < (numAddrs + 100); i++ {
 		numString := strconv.Itoa(i)
 		buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6") //base address string
+		//buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA60A109A21AEC019107BA60A10") //base address string
 
 		buffer.WriteString(numString) //adding on final two digits to make addresses unique
 		res, _ := sdk.AccAddressFromHex(buffer.String())


### PR DESCRIPTION
You may ignore the PR. This is just give you a hint to make a progress.

### Main action
* Use internal address type
* Inject additional dummy 12 byte '0' to address when the address need sending to EE layer

### Background
`add-el-genesis-account` cannot accept friday account

### Studies

#### Workaround 1
Make the length of friday account to 32
* Definitely clear implementation if it works

`github.com/hdac-io/friday/types/address.go`

```go
	// AddrLen defines a valid address length
	AddrLen = 32 // Previous 20
	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
	Bech32MainPrefix = "friday"
```

But changing setting doesn't work and many malfunctions in crypto/keys
(CLI cannot find key from internal goleveldb and its info)

#### Workaround 2
Inject additional 12 byte '0' to address, and send to EE layer
* Not pretty but feasible
* Changed genesis account types, and did accordingly, too

Please check changed files.

* Test error in querying custom contracts
  * If you accept this workaround, querying with address logic will be revised accordingly

### Result

```bash
fryd init <moniker> --chain-id namechain
friday keys add jack
friday keys add alice

fryd add-genesis-account $(friday keys show jack -a) 1000nametoken,100000000stake
fryd add-genesis-account $(friday keys show alice -a) 1000nametoken,100000000stake
fryd add-el-genesis-account $(friday keys show jack -a) "500000000" "1000000"
fryd add-el-genesis-account $(friday keys show alice -a) "500000000" "1000000"

friday config chain-id namechain
friday config output json
friday config indent true
friday config trust-node true

fryd gentx --name jack
fryd collect-gentxs  # DO NOT MISS HERE (Generates validation and inject to genesis.json)
fryd validate-genesis
fryd start
```