### PR TITLE
Rewrited address system to custom publickey

### DIFF
--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc/transforms"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
+	"github.com/hdac-io/friday/x/executionlayer/types"
 	"github.com/stretchr/testify/assert"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -30,7 +31,7 @@ func TestGetQueryResult(t *testing.T) {
 	res, err := input.elk.GetQueryResult(
 		input.ctx,
 		parentHash,
-		"address", input.strGenesisAddress, queryPath)
+		"address", input.genesisAddress.String(), queryPath)
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -45,7 +46,7 @@ func TestGetQueryResult(t *testing.T) {
 func TestGetQueryBalanceResult(t *testing.T) {
 	input := setupTestInput()
 	parentHash := genesis(input.elk)
-	res, err := input.elk.GetQueryBalanceResult(input.ctx, parentHash, input.strGenesisAddress)
+	res, err := input.elk.GetQueryBalanceResult(input.ctx, parentHash, types.ToPublicKey(input.genesisAddress))
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -1,7 +1,6 @@
 package executionlayer
 
 import (
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/codec"
 	sdk "github.com/hdac-io/friday/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -42,7 +41,7 @@ func queryEEDetail(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, errmsg := keeper.GetQueryResult(ctx, param.StateHash, param.KeyType, util.EncodeToHexString(param.KeyData), param.Path)
+	val, errmsg := keeper.GetQueryResult(ctx, param.StateHash, param.KeyType, param.KeyData, param.Path)
 	if errmsg != nil {
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, errmsg.Error())
 	}
@@ -62,7 +61,7 @@ func queryEE(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Execu
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, errmsg := keeper.GetQueryResultSimple(ctx, param.KeyType, string(param.KeyData), param.Path)
+	val, errmsg := keeper.GetQueryResultSimple(ctx, param.KeyType, param.KeyData, param.Path)
 	if errmsg != nil {
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, errmsg.Error())
 	}
@@ -82,7 +81,7 @@ func queryBalanceDetail(ctx sdk.Context, path []string, req abci.RequestQuery, k
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, err := keeper.GetQueryBalanceResult(ctx, param.StateHash, string(param.Address))
+	val, err := keeper.GetQueryBalanceResult(ctx, param.StateHash, param.Address)
 	if err != nil {
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, err.Error())
 	}

--- a/x/executionlayer/querier_test.go
+++ b/x/executionlayer/querier_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	sdk "github.com/hdac-io/friday/types"
+	"github.com/hdac-io/friday/x/executionlayer/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -30,7 +30,7 @@ func TestQueryEEDetail(t *testing.T) {
 	queryData := QueryExecutionLayerDetail{
 		StateHash: parentHash,
 		KeyType:   "address",
-		KeyData:   util.DecodeHexString(input.strGenesisAddress),
+		KeyData:   input.genesisAddress.String(),
 		Path:      queryPath,
 	}
 
@@ -53,7 +53,7 @@ func TestQueryBalanceDetail(t *testing.T) {
 
 	queryData := QueryGetBalanceDetail{
 		StateHash: parentHash,
-		Address:   input.strGenesisAddress,
+		Address:   types.ToPublicKey(input.genesisAddress),
 	}
 
 	bz, _ := input.cdc.MarshalJSON(queryData)

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -55,6 +55,7 @@ func setupTestInput() testInput {
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id"}, false, log.NewNopLogger())
 
 	blockStateHash := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
+
 	genesisAddress, _ := sdk.AccAddressFromBech32("friday1dl2cjlfpmc9hcyd4rxts047tze87s0gxmzqx70")
 	strGenesisAddress := util.EncodeToHexString(types.ToPublicKey(genesisAddress))
 	chainName := "hdac"
@@ -92,7 +93,7 @@ func setupTestInput() testInput {
 
 func genesis(keeper ExecutionLayerKeeper) []byte {
 	input := setupTestInput()
-	fmt.Printf("%v", input.genesisAccount)
+	fmt.Printf("%v\n", input.genesisAccount)
 	genesisConfig, err := util.GenesisConfigMock(
 		input.chainName, input.strGenesisAddress,
 		input.genesisAccount[input.strGenesisAddress][0],
@@ -127,14 +128,14 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
 
-	effects2, err := grpc.Execute(keeper.client, parentStateHash, timestamp, deploys, keeper.protocolVersion)
-	if err != "" {
-		panic(fmt.Sprintf("counter define execute: %s", err))
+	effects2, grpcErr := grpc.Execute(keeper.client, parentStateHash, timestamp, deploys, keeper.protocolVersion)
+	if grpcErr != "" {
+		panic(fmt.Sprintf("counter define execute: %s", grpcErr))
 	}
 
-	postStateHash, _, err := grpc.Commit(keeper.client, parentStateHash, effects2, keeper.protocolVersion)
-	if err != "" {
-		panic(fmt.Sprintf("counter define commmit: %s", err))
+	postStateHash, _, grpcErr := grpc.Commit(keeper.client, parentStateHash, effects2, keeper.protocolVersion)
+	if grpcErr != "" {
+		panic(fmt.Sprintf("counter define commmit: %s", grpcErr))
 	}
 
 	return postStateHash
@@ -150,18 +151,19 @@ func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 
 	timestamp = time.Now().Unix()
 	deploy := util.MakeDeploy(input.strGenesisAddress, cntCallCode,
+
 		[]byte{}, standardPaymentCode, paymentAbi, uint64(10), timestamp, input.chainName)
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
 
-	effects3, err := grpc.Execute(keeper.client, parentStateHash, timestamp, deploys, keeper.protocolVersion)
-	if err != "" {
-		panic(fmt.Sprintf("counter call execute: %s", err))
+	effects3, grpcErr := grpc.Execute(keeper.client, parentStateHash, timestamp, deploys, keeper.protocolVersion)
+	if grpcErr != "" {
+		panic(fmt.Sprintf("counter call execute: %s", grpcErr))
 	}
 
-	postStateHash, _, err := grpc.Commit(keeper.client, parentStateHash, effects3, keeper.protocolVersion)
-	if err != "" {
-		panic(fmt.Sprintf("counter call commit: %s", err))
+	postStateHash, _, grpcErr := grpc.Commit(keeper.client, parentStateHash, effects3, keeper.protocolVersion)
+	if grpcErr != "" {
+		panic(fmt.Sprintf("counter call commit: %s", grpcErr))
 	}
 
 	return postStateHash

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 )
 
-// QueryExecutionLayer payload for a EE query
+// QueryExecutionLayerDetail payload for a EE query
 type QueryExecutionLayerDetail struct {
 	StateHash []byte `json:"state_hash"`
 	KeyType   string `json:"key_type"`
-	KeyData   []byte `json:"key_data"`
+	KeyData   string `json:"key_data"`
 	Path      string `json:"path"`
 }
 
@@ -20,7 +20,7 @@ func (q QueryExecutionLayerDetail) String() string {
 // QueryExecutionLayer payload for a EE query
 type QueryExecutionLayer struct {
 	KeyType string `json:"key_type"`
-	KeyData []byte `json:"key_data"`
+	KeyData string `json:"key_data"`
 	Path    string `json:"path"`
 }
 
@@ -32,7 +32,7 @@ func (q QueryExecutionLayer) String() string {
 // QueryGetBalanceDetail payload for balance query
 type QueryGetBalanceDetail struct {
 	StateHash []byte
-	Address   string
+	Address   PublicKey
 }
 
 // implement fmt.Stringer
@@ -42,7 +42,7 @@ func (q QueryGetBalanceDetail) String() string {
 
 // QueryGetBalance payload for balance query in the latest data
 type QueryGetBalance struct {
-	Address string
+	Address PublicKey
 }
 
 // implement fmt.Stringer


### PR DESCRIPTION
### Change
* Rewrite query logic according to public key type change
* Type conversion for address in general contract execution

### Test
Please do the following:

```bash
nodef init <moniker> --chain-id friday-devnet
clif keys add jack
clif keys add alice

nodef add-genesis-account $(clif keys show jack -a) 1000nametoken,100000000stake
nodef add-genesis-account $(clif keys show alice -a) 1000nametoken,100000000stake
nodef add-el-genesis-account $(clif keys show jack -a) "500000000" "1000000"
nodef add-el-genesis-account $(clif keys show alice -a) "500000000" "1000000"

clif config chain-id friday-devnet
clif config output json
clif config indent true
clif config trust-node true

nodef gentx --name jack
nodef collect-gentxs
nodef validate-genesis
nodef start

################

clif query executionlayer getbalance $(clif keys show jack -a)
clif query executionlayer getbalance $(clif keys show bryan -a)

# {
#  "value": "500000000"
#  }
```
