### PR TITLE
fix: load-chainspec overwrites accounts

### DIFF
--- a/cmd/nodef/genesiscmd.go
+++ b/cmd/nodef/genesiscmd.go
@@ -77,7 +77,7 @@ the base64 encoded publickey and a list of initial coins.`,
 				cdc.MustUnmarshalJSON(appState[eltypes.ModuleName], &genesisState)
 			}
 
-			genesisState.GenesisConf.Genesis.Accounts = append(genesisState.GenesisConf.Genesis.Accounts, account)
+			genesisState.Accounts = append(genesisState.Accounts, account)
 			genesisStateBytes, err := cdc.MarshalJSON(genesisState)
 			if err != nil {
 				return fmt.Errorf("failed to marshal executionlayer genesis state: %w", err)

--- a/x/executionlayer/configuration/chainspec_test.go
+++ b/x/executionlayer/configuration/chainspec_test.go
@@ -22,7 +22,6 @@ func genesisConfigMock() types.GenesisConf {
 			Timestamp:       1568805354071,
 			MintWasm:        []byte("mint contract bytes"),
 			PosWasm:         []byte("pos contract bytes"),
-			Accounts:        nil,
 			ProtocolVersion: "1.0.0",
 		},
 		WasmCosts: types.WasmCosts{
@@ -49,7 +48,6 @@ func TestParseGenesisChainSpecBasic(t *testing.T) {
 	require.Equal(t, expected.Genesis.Timestamp, got.Genesis.Timestamp)
 	require.Equal(t, expected.Genesis.MintWasm, got.Genesis.MintWasm)
 	require.Equal(t, expected.Genesis.PosWasm, got.Genesis.PosWasm)
-	require.Equal(t, expected.Genesis.Accounts, got.Genesis.Accounts)
 	require.Equal(t, expected.Genesis.ProtocolVersion, got.Genesis.ProtocolVersion)
 
 	if !reflect.DeepEqual(expected.WasmCosts, got.WasmCosts) {

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -13,7 +13,7 @@ import (
 // InitGenesis sets an executionlayer configuration for genesis.
 func InitGenesis(
 	ctx sdk.Context, keeper ExecutionLayerKeeper, data types.GenesisState) {
-	genesisConfig, err := types.ToChainSpecGenesisConfig(data.GenesisConf)
+	genesisConfig, err := types.ToChainSpecGenesisConfig(data)
 	if err != nil {
 		panic(err)
 	}
@@ -36,11 +36,12 @@ func InitGenesis(
 		panic(response.GetResult())
 	}
 
+	keeper.SetGenesisAccounts(ctx, data.Accounts)
 	keeper.SetGenesisConf(ctx, data.GenesisConf)
 	keeper.SetEEState(ctx, ctx.BlockHeader().LastBlockId.Hash, response.GetSuccess().GetPoststateHash())
 }
 
 // ExportGenesis : exports an executionlayer configuration for genesis
 func ExportGenesis(ctx sdk.Context, keeper ExecutionLayerKeeper) types.GenesisState {
-	return types.NewGenesisState(keeper.GetGenesisConf(ctx))
+	return types.NewGenesisState(keeper.GetGenesisConf(ctx), keeper.GetGenesisAccounts(ctx))
 }

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -196,6 +196,28 @@ func (k ExecutionLayerKeeper) SetGenesisConf(ctx sdk.Context, genesisConf types.
 	store.Set([]byte("genesisconf"), genesisConfBytes)
 }
 
+// GetGenesisAccounts retrieves GenesisAccounts in sdk store
+func (k ExecutionLayerKeeper) GetGenesisAccounts(ctx sdk.Context) []types.Account {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	genesisAccountsBytes := store.Get([]byte("genesisaccounts"))
+	if genesisAccountsBytes == nil {
+		return nil
+	}
+	var genesisAccounts []types.Account
+	k.cdc.UnmarshalBinaryBare(genesisAccountsBytes, &genesisAccounts)
+	return genesisAccounts
+}
+
+// SetGenesisAccounts saves GenesisAccounts in sdk store
+func (k ExecutionLayerKeeper) SetGenesisAccounts(ctx sdk.Context, accounts []types.Account) {
+	if accounts == nil {
+		return
+	}
+	store := ctx.KVStore(k.HashMapStoreKey)
+	genesisAccountsBytes := k.cdc.MustMarshalBinaryBare(accounts)
+	store.Set([]byte("genesisaccounts"), genesisAccountsBytes)
+}
+
 // GetCurrentBlockHash returns current block hash
 func (k ExecutionLayerKeeper) GetCurrentBlockHash(ctx sdk.Context) []byte {
 	store := ctx.KVStore(k.HashMapStoreKey)

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -150,4 +151,31 @@ func TestMarsahlAndUnMarshal(t *testing.T) {
 	proto.Unmarshal(bz, obj)
 
 	assert.Equal(t, src.Transform.String(), obj.Transform.String())
+}
+
+func TestGenesisState(t *testing.T) {
+	testMock := setupTestInput()
+
+	expected := types.DefaultGenesisState()
+	testMock.elk.SetGenesisConf(testMock.ctx, expected.GenesisConf)
+	testMock.elk.SetGenesisAccounts(testMock.ctx, expected.Accounts)
+
+	var got types.GenesisState
+	got.GenesisConf = testMock.elk.GetGenesisConf(testMock.ctx)
+	got.Accounts = testMock.elk.GetGenesisAccounts(testMock.ctx)
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected: %v, but got: %v", expected, got)
+	}
+
+	// accounts Marshal, UnMarshal test
+	expected.Accounts = make([]types.Account, 1)
+	expected.Accounts[0].PublicKey = types.PublicKey([]byte("test-pub-key"))
+	expected.Accounts[0].InitialBalance = "2"
+	expected.Accounts[0].InitialBondedAmount = "1"
+
+	testMock.elk.SetGenesisAccounts(testMock.ctx, expected.Accounts)
+	gottonAccounts := testMock.elk.GetGenesisAccounts(testMock.ctx)
+	if !reflect.DeepEqual(expected.Accounts, gottonAccounts) {
+		t.Errorf("expected: %v, but got: %v", expected.Accounts, gottonAccounts)
+	}
 }

--- a/x/executionlayer/types/genesis.go
+++ b/x/executionlayer/types/genesis.go
@@ -11,6 +11,7 @@ import (
 // GenesisState : the executionlayer state that must be provided at genesis.
 type GenesisState struct {
 	GenesisConf GenesisConf `json:"genesis_conf"`
+	Accounts    []Account   `json:"accounts"`
 }
 
 // GenesisConf : the executionlayer configuration that must be provided at genesis.
@@ -21,12 +22,11 @@ type GenesisConf struct {
 
 // Genesis : Chain Genesis information
 type Genesis struct {
-	Name            string    `json:"name"`
-	Timestamp       uint64    `json:"timestamp"`
-	MintWasm        []byte    `json:"mint_wasm"`
-	PosWasm         []byte    `json:"pos_wasm"`
-	Accounts        []Account `json:"accounts"`
-	ProtocolVersion string    `json:"protocol_version"`
+	Name            string `json:"name"`
+	Timestamp       uint64 `json:"timestamp"`
+	MintWasm        []byte `json:"mint_wasm"`
+	PosWasm         []byte `json:"pos_wasm"`
+	ProtocolVersion string `json:"protocol_version"`
 }
 
 // Account : Genesis Account Information.
@@ -52,8 +52,8 @@ type WasmCosts struct {
 }
 
 // NewGenesisState creates a new genesis state.
-func NewGenesisState(genesisConf GenesisConf) GenesisState {
-	return GenesisState{GenesisConf: genesisConf}
+func NewGenesisState(genesisConf GenesisConf, accounts []Account) GenesisState {
+	return GenesisState{GenesisConf: genesisConf, Accounts: accounts,}
 }
 
 // DefaultGenesisState returns a default genesis state
@@ -64,7 +64,6 @@ func DefaultGenesisState() GenesisState {
 			Timestamp:       0,
 			MintWasm:        DefaultMintWasm,
 			PosWasm:         DefaultPosWasm,
-			Accounts:        nil,
 			ProtocolVersion: "1.0.0",
 		},
 		WasmCosts: WasmCosts{
@@ -80,25 +79,26 @@ func DefaultGenesisState() GenesisState {
 			OpcodesDivisor:    8,
 		},
 	}
-	return NewGenesisState(genesisConf)
+	return NewGenesisState(genesisConf, nil)
 }
 
 // ValidateGenesis :
 func ValidateGenesis(data GenesisState) error {
-	_, err := ToChainSpecGenesisConfig(data.GenesisConf)
+	_, err := ToChainSpecGenesisConfig(data)
 	return err
 }
 
-func ToChainSpecGenesisConfig(config GenesisConf) (*ipc.ChainSpec_GenesisConfig, error) {
+func ToChainSpecGenesisConfig(gs GenesisState) (*ipc.ChainSpec_GenesisConfig, error) {
+	config := gs.GenesisConf
 	pv, err := toProtocolVersion(config.Genesis.ProtocolVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	var accounts []*ipc.ChainSpec_GenesisAccount
-	if n := len(config.Genesis.Accounts); n != 0 {
+	if n := len(gs.Accounts); n != 0 {
 		accounts = make([]*ipc.ChainSpec_GenesisAccount, n)
-		for i, v := range config.Genesis.Accounts {
+		for i, v := range gs.Accounts {
 			account := toChainSpecGenesisAccount(v)
 			accounts[i] = &account
 		}

--- a/x/executionlayer/types/genesis_test.go
+++ b/x/executionlayer/types/genesis_test.go
@@ -46,11 +46,11 @@ func TestToProtocolVersion(t *testing.T) {
 func TestToChainSpecGenesisConfig(t *testing.T) {
 	// valid input
 	genesisState := DefaultGenesisState()
-	_, err := ToChainSpecGenesisConfig(genesisState.GenesisConf)
+	_, err := ToChainSpecGenesisConfig(genesisState)
 	require.Nil(t, err)
 
 	// invalid protocol version
 	genesisState.GenesisConf.Genesis.ProtocolVersion = "1.0.0.0"
-	_, err = ToChainSpecGenesisConfig(genesisState.GenesisConf)
+	_, err = ToChainSpecGenesisConfig(genesisState)
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
if load-chainspec is executed after add-el-genesis-account, load-chainspec cmd would overwrite accounts with null in executionlayer in genesis.json.

fix the problem by separating Accounts from GenesisConf.