### PR TITLE
set max tx bytes and body bytes to 3MiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,6 @@ nodef gentx --name elsa # insert password
 nodef collect-gentxs
 nodef validate-genesis
 ```
-* edit ~/.nodef/config/config.toml
-```
-...
-# Maximum size of request body, in bytes
-max_body_bytes = 1000000 -> 3000000
-...
-# Maximum size of a single transaction.
-# NOTE: the max size of a tx transmitted over the network is {max_tx_bytes} + {amino overhead}.
-max_tx_bytes = 1048576 -> 3145728
-...
-```
 * genesis node start
 ```
 nodef start
@@ -134,15 +123,8 @@ nodef init <node_name> --chain-id testnet
 * edit ~/.nodef/config/config.toml
 ```
 ...
-# Maximum size of request body, in bytes
-max_body_bytes = 1000000 -> 3000000
-...
 # Comma separated list of seed nodes to connect to
 seeds = "" -> "<genesis node's ID>@<genesis node's IP>:26656"
-...
-# Maximum size of a single transaction.
-# NOTE: the max size of a tx transmitted over the network is {max_tx_bytes} + {amino overhead}.
-max_tx_bytes = 1048576 -> 3145728
 ...
 ```
 * replace `~/.nodef/config/genesis.json` to genesis node's one what you saved above.

--- a/README.md
+++ b/README.md
@@ -131,5 +131,9 @@ seeds = "" -> "<genesis node's ID>@<genesis node's IP>:26656"
 ## Test
 
 ```
-$ make test
+# run execution engine grpc server
+./CasperLabs/execution-engine/target/release/casperlabs-engine-grpc-server $HOME/.casperlabs/.casper-node.sock
+
+# run test
+make test
 ```

--- a/server/util.go
+++ b/server/util.go
@@ -93,6 +93,10 @@ func interceptLoadConfig() (conf *cfg.Config, err error) {
 		conf.P2P.SendRate = 5120000
 		conf.TxIndex.IndexAllTags = true
 		conf.Consensus.TimeoutCommit = 5 * time.Second
+		// set max body and yx bytes to 3MiB
+		maxBytes := 3 * 1024 * 1024 // 3MiB
+		conf.RPC.MaxBodyBytes = int64(maxBytes)
+		conf.Mempool.MaxTxBytes = maxBytes
 		cfg.WriteConfigFile(configFilePath, conf)
 		// Fall through, just so that its parsed into memory.
 	}


### PR DESCRIPTION
In the beginning of our tx could have wasm binary which has about 2Mib plus alpha bytes data.
So we need to enlarge our bytes' limitation.
This patch affects default config.toml file.