### PR TITLE
feat: unify chain name in config

### DIFF
--- a/cmd/nodef/genesiscmd.go
+++ b/cmd/nodef/genesiscmd.go
@@ -129,6 +129,9 @@ func LoadChainspecCmd(
 				cdc.MustUnmarshalJSON(appState[eltypes.ModuleName], &genesisState)
 			}
 
+			// execution engine also needs chain name
+			genesisState.ChainName = genDoc.ChainID
+
 			// parse chainspec toml
 			genesisConf, err := elconfig.ParseGenesisChainSpec(args[0])
 			if err != nil {

--- a/tests/resources/executionlayer/genesis/genesis_with_invalid_wasm_path.toml
+++ b/tests/resources/executionlayer/genesis/genesis_with_invalid_wasm_path.toml
@@ -1,5 +1,4 @@
 [genesis]
-name = "test-chain"
 timestamp = 1568805354071
 protocol-version = "1.0.0"
 mint-code-path = "mint_install.wasm"

--- a/tests/resources/executionlayer/genesis/genesis_with_missing_field.toml
+++ b/tests/resources/executionlayer/genesis/genesis_with_missing_field.toml
@@ -1,5 +1,4 @@
 [genesis]
-name = "test-chain"
 timestamp = 1568805354071
 # protocol-version = "1.0.0"
 mint-code-path = "mint_install.wasm"

--- a/tests/resources/executionlayer/genesis/manifest.toml
+++ b/tests/resources/executionlayer/genesis/manifest.toml
@@ -1,10 +1,4 @@
 [genesis]
-
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
-name = "test-chain"
-
 # Timestamp for the genesis block, also used in seeding the pseudo-random number
 # generator used in execution engine for computing genesis post-state.
 timestamp = 1568805354071

--- a/x/executionlayer/configuration/chainspec.go
+++ b/x/executionlayer/configuration/chainspec.go
@@ -43,11 +43,6 @@ func ParseGenesisChainSpec(chainSpecPath string) (*types.GenesisConf, error) {
 func parseGenesisTable(genesisTable *toml.Tree, chainSpecPath string) (*types.Genesis, error) {
 	genesis := types.Genesis{}
 
-	if genesisTable.Get("name") == nil {
-		return nil, types.ErrTomlParse(types.DefaultCodespace, "name")
-	}
-	genesis.Name = genesisTable.Get("name").(string)
-
 	if genesisTable.Get("timestamp") == nil {
 		return nil, types.ErrTomlParse(types.DefaultCodespace, "timestamp")
 	}

--- a/x/executionlayer/configuration/chainspec_test.go
+++ b/x/executionlayer/configuration/chainspec_test.go
@@ -18,7 +18,6 @@ const (
 func genesisConfigMock() types.GenesisConf {
 	return types.GenesisConf{
 		Genesis: types.Genesis{
-			Name:            "test-chain",
 			Timestamp:       1568805354071,
 			MintWasm:        []byte("mint contract bytes"),
 			PosWasm:         []byte("pos contract bytes"),
@@ -44,7 +43,6 @@ func TestParseGenesisChainSpecBasic(t *testing.T) {
 	got, err := ParseGenesisChainSpec(path.Join(testResourceDir, "manifest.toml"))
 	require.Nil(t, err)
 	expected := genesisConfigMock()
-	require.Equal(t, expected.Genesis.Name, got.Genesis.Name)
 	require.Equal(t, expected.Genesis.Timestamp, got.Genesis.Timestamp)
 	require.Equal(t, expected.Genesis.MintWasm, got.Genesis.MintWasm)
 	require.Equal(t, expected.Genesis.PosWasm, got.Genesis.PosWasm)

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -39,11 +39,13 @@ func InitGenesis(
 	if data.Accounts != nil {
 		keeper.SetGenesisAccounts(ctx, data.Accounts)
 	}
+	keeper.SetChainName(ctx, data.ChainName)
 	keeper.SetGenesisConf(ctx, data.GenesisConf)
 	keeper.SetEEState(ctx, ctx.BlockHeader().LastBlockId.Hash, response.GetSuccess().GetPoststateHash())
 }
 
 // ExportGenesis : exports an executionlayer configuration for genesis
 func ExportGenesis(ctx sdk.Context, keeper ExecutionLayerKeeper) types.GenesisState {
-	return types.NewGenesisState(keeper.GetGenesisConf(ctx), keeper.GetGenesisAccounts(ctx))
+	return types.NewGenesisState(
+		keeper.GetGenesisConf(ctx), keeper.GetGenesisAccounts(ctx), keeper.GetChainName(ctx))
 }

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -232,6 +232,22 @@ func (k ExecutionLayerKeeper) SetGenesisAccounts(ctx sdk.Context, accounts []typ
 	store.Set([]byte("genesisaccounts"), genesisAccountsBytes)
 }
 
+// GetChainName retrieves ChainName in sdk store
+func (k ExecutionLayerKeeper) GetChainName(ctx sdk.Context) string {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	chainNameBytes := store.Get([]byte("chainname"))
+	return string(chainNameBytes)
+}
+
+// SetChainName saves ChainName in sdk store
+func (k ExecutionLayerKeeper) SetChainName(ctx sdk.Context, chainName string) {
+	if chainName == "" {
+		panic(fmt.Errorf("Empty string is not allowed for ChainName"))
+	}
+	store := ctx.KVStore(k.HashMapStoreKey)
+	store.Set([]byte("chainname"), []byte(chainName))
+}
+
 // GetCurrentBlockHash returns current block hash
 func (k ExecutionLayerKeeper) GetCurrentBlockHash(ctx sdk.Context) []byte {
 	store := ctx.KVStore(k.HashMapStoreKey)

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -168,7 +168,6 @@ func TestGenesisState(t *testing.T) {
 	if !reflect.DeepEqual(expected.GenesisConf.WasmCosts, got.GenesisConf.WasmCosts) {
 		t.Errorf("expected: %v, but got: %v", expected.GenesisConf.WasmCosts, got.GenesisConf.WasmCosts)
 	}
-	assert.Equal(t, expected.GenesisConf.Genesis.Name, got.GenesisConf.Genesis.Name)
 	assert.Equal(t, expected.GenesisConf.Genesis.Timestamp, got.GenesisConf.Genesis.Timestamp)
 	assert.Equal(t, expected.GenesisConf.Genesis.ProtocolVersion, got.GenesisConf.Genesis.ProtocolVersion)
 	assert.Equal(t, expected.GenesisConf.Genesis.MintWasm, got.GenesisConf.Genesis.MintWasm)
@@ -185,4 +184,10 @@ func TestGenesisState(t *testing.T) {
 	if !reflect.DeepEqual(expected.Accounts, gottonAccounts) {
 		t.Errorf("expected: %v, but got: %v", expected.Accounts, gottonAccounts)
 	}
+
+	// ChainName test
+	expected.ChainName = "keeper-test-chain-name"
+	testMock.elk.SetChainName(testMock.ctx, expected.ChainName)
+	gottonChainName := testMock.elk.GetChainName(testMock.ctx)
+	assert.Equal(t, expected.ChainName, gottonChainName)
 }

--- a/x/executionlayer/resources/manifest.toml
+++ b/x/executionlayer/resources/manifest.toml
@@ -1,11 +1,5 @@
 # CasperLabs Execution Engine Chainspec
 [genesis]
-
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
-name = "monday-0001"
-
 # Timestamp for the genesis block, also used in seeding the pseudo-random number
 # generator used in execution engine for computing genesis post-state.
 timestamp = 0

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -56,7 +56,7 @@ func setupTestInput() testInput {
 	elk := NewExecutionLayerKeeper(cdc, hashMapStoreKey, os.ExpandEnv("$HOME/.casperlabs/.casper-node.sock"))
 
 	gs := types.DefaultGenesisState()
-	gs.GenesisConf.Genesis.Name = chainID
+	gs.ChainName = chainID
 	gs.Accounts = make([]types.Account, 1)
 	gs.Accounts[0] = types.Account{
 		PublicKey:           types.ToPublicKey(GenesisAccountAddress),
@@ -101,7 +101,7 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
 
 	deploy := util.MakeDeploy(input.elk.GetGenesisAccounts(input.ctx)[0].PublicKey, cntDefCode, []byte{},
-		standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetGenesisConf(input.ctx).Genesis.Name)
+		standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
 
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
@@ -130,8 +130,7 @@ func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 
 	timestamp = time.Now().Unix()
 	deploy := util.MakeDeploy(input.elk.GetGenesisAccounts(input.ctx)[0].PublicKey, cntCallCode,
-
-		[]byte{}, standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetGenesisConf(input.ctx).Genesis.Name)
+		[]byte{}, standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
 

--- a/x/executionlayer/types/genesis.go
+++ b/x/executionlayer/types/genesis.go
@@ -12,6 +12,7 @@ import (
 type GenesisState struct {
 	GenesisConf GenesisConf `json:"genesis_conf"`
 	Accounts    []Account   `json:"accounts"`
+	ChainName string `json:"chain_name"`
 }
 
 // GenesisConf : the executionlayer configuration that must be provided at genesis.
@@ -22,7 +23,6 @@ type GenesisConf struct {
 
 // Genesis : Chain Genesis information
 type Genesis struct {
-	Name            string `json:"name"`
 	Timestamp       uint64 `json:"timestamp"`
 	MintWasm        []byte `json:"mint_wasm"`
 	PosWasm         []byte `json:"pos_wasm"`
@@ -52,15 +52,14 @@ type WasmCosts struct {
 }
 
 // NewGenesisState creates a new genesis state.
-func NewGenesisState(genesisConf GenesisConf, accounts []Account) GenesisState {
-	return GenesisState{GenesisConf: genesisConf, Accounts: accounts}
+func NewGenesisState(genesisConf GenesisConf, accounts []Account, chainName string) GenesisState {
+	return GenesisState{GenesisConf: genesisConf, Accounts: accounts, ChainName: chainName,}
 }
 
 // DefaultGenesisState returns a default genesis state
 func DefaultGenesisState() GenesisState {
 	genesisConf := GenesisConf{
 		Genesis: Genesis{
-			Name:            "friday-devnet",
 			Timestamp:       0,
 			MintWasm:        DefaultMintWasm,
 			PosWasm:         DefaultPosWasm,
@@ -79,7 +78,7 @@ func DefaultGenesisState() GenesisState {
 			OpcodesDivisor:    8,
 		},
 	}
-	return NewGenesisState(genesisConf, nil)
+	return NewGenesisState(genesisConf, nil, "friday-devnet")
 }
 
 // ValidateGenesis :
@@ -105,7 +104,7 @@ func ToChainSpecGenesisConfig(gs GenesisState) (*ipc.ChainSpec_GenesisConfig, er
 	}
 
 	chainSpecConfig := ipc.ChainSpec_GenesisConfig{
-		Name:            config.Genesis.Name,
+		Name:            gs.ChainName,
 		Timestamp:       config.Genesis.Timestamp,
 		ProtocolVersion: pv,
 		MintInstaller:   config.Genesis.MintWasm,


### PR DESCRIPTION
remove genesis.name field in chainspec toml
and use chain_id as chain name for the execution engine.