### PR TITLE
Add new account logic & detach bank module from EE

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ clif status | grep \"id\"
 
 ### Clif usage
 * query
-  * usage: `clif query executionlayer getbalance [address]`
+  * usage: `clif executionlayer getbalance [address]`
 ```
-clif query executionlayer getbalance $(clif keys show elsa -a)
+clif executionlayer getbalance $(clif keys show elsa -a)
 
 {
    "value": "5000000000000"
@@ -86,10 +86,10 @@ clif query executionlayer getbalance $(clif keys show elsa -a)
 ```
 
 * transfer (send)
-  * usage: `clif tx executionlayer transfer [token_contract_address] [from_address] [to_address]  [amount] [fee] [gas_price]`
+  * usage: `clif executionlayer transfer [token_contract_address] [from_address] [to_address]  [amount] [fee] [gas_price]`
   * `token_contract_address` is currently dummy, and you may input as same as `from_address`
 ```
-clif tx executionlayer transfer $(clif keys show elsa -a) $(clif keys show elsa -a) $(clif keys show anna -a) 1000000 100000000 20000000
+clif executionlayer transfer $(clif keys show elsa -a) $(clif keys show elsa -a) $(clif keys show anna -a) 1000000 100000000 20000000
 
 ...
 confirm transaction before signing and broadcasting [y/N]: y
@@ -119,9 +119,9 @@ Password to sign with 'elsa': # input your password
 }
 ```
 * bond
-  * usage: `clif tx executionlayer bond [from_address] [bond_amount] [fee] [gas_price]`
+  * usage: `clif executionlayer bond [from_address] [bond_amount] [fee] [gas_price]`
 ```
-./clif tx executionlayer bond $(clif keys show elsa -a) 10000000 100000000 20000000
+./clif executionlayer bond $(clif keys show elsa -a) 10000000 100000000 20000000
 
 confirm transaction before signing and broadcasting [y/N]: y
 Password to sign with 'bryan':
@@ -151,9 +151,9 @@ Password to sign with 'bryan':
 ```
 
 * unbond
-  * usage: `clif tx executionlayer unbond [from_address] [unbond_amount] [fee] [gas_price]`
+  * usage: `clif executionlayer unbond [from_address] [unbond_amount] [fee] [gas_price]`
 ```
-./clif tx executionlayer unbond $(clif keys show elsa -a) 10000000 100000000 20000000
+./clif executionlayer unbond $(clif keys show elsa -a) 10000000 100000000 20000000
 
 confirm transaction before signing and broadcasting [y/N]: y
 Password to sign with 'bryan':

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ clif query executionlayer getbalance $(clif keys show elsa -a)
 ```
 
 * transfer (send)
-  * usage: `clif tx send [from address] [to address]  [amount] [fee] [gas_price]`
+  * usage: `clif tx executionlayer transfer [token_contract_address] [from_address] [to_address]  [amount] [fee] [gas_price]`
+  * `token_contract_address` is currently dummy, and you may input as same as `from_address`
 ```
-clif tx send $(clif keys show elsa -a) $(clif keys show anna -a) 100dummy 100000000 20000000
+clif tx executionlayer transfer $(clif keys show elsa -a) $(clif keys show elsa -a) $(clif keys show anna -a) 1000000 100000000 20000000
 
 ...
 confirm transaction before signing and broadcasting [y/N]: y
@@ -118,9 +119,68 @@ Password to sign with 'elsa': # input your password
 }
 ```
 * bond
-  * usage: `clif executionlayer bond [from address] [bond amount] [fee] [gas_price]`
+  * usage: `clif tx executionlayer bond [from_address] [bond_amount] [fee] [gas_price]`
+```
+./clif tx executionlayer bond $(clif keys show elsa -a) 10000000 100000000 20000000
+
+confirm transaction before signing and broadcasting [y/N]: y
+Password to sign with 'bryan':
+{
+  "height": "0",
+  "txhash": "22DF1E0D8D9EB8BE2B5F50995C6FC0AB20E34715875A9F9856A9466A8C406807",
+  "raw_log": "[{\"msg_index\":0,\"success\":true,\"log\":\"\",\"events\":[{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"executionengine\"}]}]}]",
+  "logs": [
+    {
+      "msg_index": 0,
+      "success": true,
+      "log": "",
+      "events": [
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "executionengine"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
 * unbond
-  * usage: `clif executionlayer unbond [from address] [unbond amount] [fee] [gas_price]`
+  * usage: `clif tx executionlayer unbond [from_address] [unbond_amount] [fee] [gas_price]`
+```
+./clif tx executionlayer unbond $(clif keys show elsa -a) 10000000 100000000 20000000
+
+confirm transaction before signing and broadcasting [y/N]: y
+Password to sign with 'bryan':
+{
+  "height": "0",
+  "txhash": "69C51D25E3E5DB4F2D4ACE832C775DC8EE993E9CDB7560A3AF470FF07CC7FFC9",
+  "raw_log": "[{\"msg_index\":0,\"success\":true,\"log\":\"\",\"events\":[{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"executionengine\"}]}]}]",
+  "logs": [
+    {
+      "msg_index": 0,
+      "success": true,
+      "log": "",
+      "events": [
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "executionengine"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
 ### Connect to seed node
 * run this on another machine

--- a/app/app.go
+++ b/app/app.go
@@ -171,7 +171,8 @@ func NewFridayApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 	app.executionLayerKeeper = executionlayer.NewExecutionLayerKeeper(
 		app.cdc,
 		keys[executionlayer.HashMapStoreKey],
-		os.ExpandEnv("$HOME/.casperlabs/.casper-node.sock"))
+		os.ExpandEnv("$HOME/.casperlabs/.casper-node.sock"),
+		app.accountKeeper)
 
 	// register the proposal types
 	govRouter := gov.NewRouter()

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -109,6 +109,7 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		viper.BindPFlag(FlagTrustNode, c.Flags().Lookup(FlagTrustNode))
 		viper.BindPFlag(FlagUseLedger, c.Flags().Lookup(FlagUseLedger))
 		viper.BindPFlag(FlagNode, c.Flags().Lookup(FlagNode))
+		viper.BindPFlag(FlagBroadcastMode, c.Flags().Lookup(FlagBroadcastMode))
 
 		c.MarkFlagRequired(FlagChainID)
 	}

--- a/cmd/clif/main.go
+++ b/cmd/clif/main.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/tendermint/go-amino"
 	"github.com/hdac-io/tendermint/libs/cli"
+	"github.com/tendermint/go-amino"
 
 	"github.com/hdac-io/friday/app"
 )
@@ -59,7 +59,7 @@ func main() {
 	// Construct Root Command
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
-		eecmd.GetExecutionLayerTxCmd(cdc),
+		eecmd.GetExecutionLayerCmd(cdc),
 		client.ConfigCmd(app.DefaultCLIHome),
 		queryCmd(cdc),
 		txCmd(cdc),

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -14,6 +14,7 @@ const (
 var (
 	// function aliases
 	NewMsgExecute  = types.NewMsgExecute
+	NewMsgTransfer = types.NewMsgTransfer
 	RegisterCodec  = types.RegisterCodec
 	NewUnitHashMap = types.NewUnitHashMap
 

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -11,7 +11,7 @@ import (
 func GetExecutionLayerCmd(cdc *codec.Codec) *cobra.Command {
 	executionlayerTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      "Tx commands for execution layer",
+		Short:                      "Commands for execution layer",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"github.com/hdac-io/friday/client"
+	"github.com/hdac-io/friday/codec"
+	"github.com/hdac-io/friday/x/executionlayer/types"
+	"github.com/spf13/cobra"
+)
+
+// GetExecutionLayerCmd controls Tx request of CLI interface
+func GetExecutionLayerCmd(cdc *codec.Codec) *cobra.Command {
+	executionlayerTxCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Tx commands for execution layer",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+	executionlayerTxCmd.AddCommand(client.GetCommands(
+		// Tx
+		GetCmdTransfer(cdc),
+		GetCmdBonding(cdc),
+		GetCmdUnbonding(cdc),
+
+		// Query
+		GetCmdQueryBalance(cdc),
+		GetCmdQueryBalanceWithBlockHash(cdc),
+		GetCmdQuery(cdc),
+		GetCmdQueryWithHash(cdc),
+	)...)
+	return executionlayerTxCmd
+}

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -38,7 +38,7 @@ func GetExecutionLayerTxCmd(cdc *codec.Codec) *cobra.Command {
 // GetCmdTransfer is the CLI command for transfer
 func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "transfer [tokenb_owner_address] [from_key_or_address] [to_address] [amount] [fee] [gas_price]",
+		Use:   "transfer [token_owner_address] [from_key_or_address] [to_address] [amount] [fee] [gas_price]",
 		Short: "Create and sign a send tx",
 		Args:  cobra.ExactArgs(6), // # of arguments
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -79,6 +79,7 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 
 			// build and sign the transaction, then broadcast to Tendermint
 			msg := types.NewMsgTransfer(tokenOwnerAddress, fromAddress, toAddress, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)
+			txBldr = txBldr.WithGas(gasPrice)
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -38,12 +38,12 @@ func GetExecutionLayerTxCmd(cdc *codec.Codec) *cobra.Command {
 // GetCmdTransfer is the CLI command for transfer
 func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "transfer [token_owner_address] [from_key_or_address] [to_address] [amount] [fee] [gas_price]",
-		Short: "Create and sign a send tx",
+		Use:   "transfer [token_owner_address] [from_address] [to_address] [amount] [fee] [gas_price]",
+		Short: "Transfer token",
 		Args:  cobra.ExactArgs(6), // # of arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
+			cliCtx := context.NewCLIContextWithFrom(args[1]).WithCodec(cdc)
 
 			tokenOwnerAddress, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -38,7 +38,7 @@ func GetExecutionLayerTxCmd(cdc *codec.Codec) *cobra.Command {
 // GetCmdTransfer is the CLI command for transfer
 func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "transfer [token_owner_address] [from_address] [to_address] [amount] [fee] [gas_price]",
+		Use:   "transfer [token_contract_address] [from_address] [to_address] [amount] [fee] [gas_price]",
 		Short: "Transfer token",
 		Args:  cobra.ExactArgs(6), // # of arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,7 +88,7 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 // GetCmdBonding is the CLI command for bonding
 func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "bond [from_key_or_address] [amount] [fee] [gas_price]",
+		Use:   "bond [address] [amount] [fee] [gas_price]",
 		Short: "Create and sign a bonding tx",
 		Args:  cobra.ExactArgs(4), // # of arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -126,7 +126,7 @@ func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 // GetCmdUnbonding is the CLI command for unbonding
 func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "unbond [from_key_or_address] [amount] [fee] [gas_price]",
+		Use:   "unbond [address] [amount] [fee] [gas_price]",
 		Short: "Create and sign a unbonding tx",
 		Args:  cobra.ExactArgs(4), // # of arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -149,7 +149,7 @@ func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 			}
 
 			unbondingCode := util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/unbonding.wasm"))
-			unbondingAbi := util.MakeArgsBonding(coins)
+			unbondingAbi := util.MakeArgsUnBonding(coins)
 			paymentCode := util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/standard_payment.wasm"))
 			paymentAbi := util.MakeArgsStandardPayment(new(big.Int).SetUint64(fee))
 

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
-	"github.com/hdac-io/friday/client"
 	"github.com/hdac-io/friday/codec"
 	"github.com/hdac-io/friday/x/executionlayer/types"
 
@@ -16,24 +15,6 @@ import (
 	"github.com/hdac-io/friday/x/auth/client/utils"
 	"github.com/spf13/cobra"
 )
-
-// GetExecutionLayerTxCmd controls Tx request of CLI interface
-func GetExecutionLayerTxCmd(cdc *codec.Codec) *cobra.Command {
-	executionlayerTxCmd := &cobra.Command{
-		Use:                        types.ModuleName,
-		Short:                      "Tx commands for execution layer",
-		DisableFlagParsing:         true,
-		SuggestionsMinimumDistance: 2,
-		RunE:                       client.ValidateCmd,
-	}
-	executionlayerTxCmd.AddCommand(client.GetCommands(
-		GetCmdTransfer(cdc), GetCmdBonding(cdc), GetCmdUnbonding(cdc),
-	)...)
-	return executionlayerTxCmd
-}
-
-// The code below is a pattern of sending Tx
-// You may start from the example first
 
 // GetCmdTransfer is the CLI command for transfer
 func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -46,22 +46,31 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 
 			tokenOwnerAddress, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil{
+			if err != nil {
 				return err
 			}
 			fromAddress, err := sdk.AccAddressFromBech32(args[1])
-			if err != nil{
+			if err != nil {
 				return err
 			}
 			toAddress, err := sdk.AccAddressFromBech32(args[2])
 			if err != nil {
 				return err
 			}
-			
+
 			toPublicKey := types.ToPublicKey(toAddress)
-			amount := uint64(args[3])
-			fee := uint64(args[4])
-			gasPrice := uint64(args[5])
+			amount, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				return err
+			}
+			fee, err := strconv.ParseUint(args[4], 10, 64)
+			if err != nil {
+				return err
+			}
+			gasPrice, err := strconv.ParseUint(args[5], 10, 64)
+			if err != nil {
+				return err
+			}
 
 			transferCode := util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/transfer_to_account.wasm"))
 			transferAbi := util.MakeArgsTransferToAccount(toPublicKey, amount)
@@ -69,7 +78,7 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 			paymentAbi := util.MakeArgsStandardPayment(new(big.Int).SetUint64(fee))
 
 			// build and sign the transaction, then broadcast to Tendermint
-			msg := types.NewMsgExecute([]byte{0}, tokenOwnerAddress, fromAddress, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)
+			msg := types.NewMsgTransfer(tokenOwnerAddress, fromAddress, toAddress, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}

--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -5,25 +5,23 @@ import (
 	"math/big"
 	"net/http"
 	"os"
-	"regexp"
-	"strconv"
 
 	grpc "github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/client/context"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/types/rest"
-	bank "github.com/hdac-io/friday/x/bank"
 	"github.com/hdac-io/friday/x/executionlayer/types"
 )
 
 type transferReq struct {
-	ChainID          string `json:"chain_id"`
-	SenderAddress    string `json:"sender_address"`
-	Amount           string `json:"amount"`
-	Fee              uint64 `json:"fee"`
-	GasPrice         uint64 `json:"gas_price"`
-	RecipientAddress string `json:"recipient_address"`
-	Memo             string `json:"memo"`
+	ChainID           string `json:"chain_id"`
+	TokenOwnerAddress string `json:"token_owner_address"`
+	SenderAddress     string `json:"sender_address"`
+	RecipientAddress  string `json:"recipient_address"`
+	Amount            uint64 `json:"amount"`
+	Fee               uint64 `json:"fee"`
+	GasPrice          uint64 `json:"gas_price"`
+	Memo              string `json:"memo"`
 }
 
 func transferMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) (rest.BaseReq, []sdk.Msg, error) {
@@ -46,43 +44,35 @@ func transferMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 	}
 
 	// Parameter touching
+	tokenowneraddr, err := sdk.AccAddressFromBech32(req.TokenOwnerAddress)
+	if err != nil {
+		return rest.BaseReq{}, nil, fmt.Errorf("wrong address type: %s", req.TokenOwnerAddress)
+	}
+
 	senderaddr, err := sdk.AccAddressFromBech32(req.SenderAddress)
 	if err != nil {
-		return rest.BaseReq{}, nil, fmt.Errorf("Wrong address type")
+		return rest.BaseReq{}, nil, fmt.Errorf("wrong address type: %s", req.SenderAddress)
 	}
 
 	receipaddr, err := sdk.AccAddressFromBech32(req.RecipientAddress)
 	if err != nil {
-		return rest.BaseReq{}, nil, err
-	}
-
-	// parse conis trying to be sent
-	coins, err := sdk.ParseCoins(req.Amount)
-	if err != nil {
-		return rest.BaseReq{}, nil, err
-	}
-
-	re := regexp.MustCompile("[0-9]+")
-	amount, err := strconv.ParseUint(re.FindAllString(req.Amount, -1)[0], 10, 64)
-	if err != nil {
-		return rest.BaseReq{}, nil, err
+		return rest.BaseReq{}, nil, fmt.Errorf("wrong address type: %s", req.RecipientAddress)
 	}
 
 	// TODO: Change after WASM store feature merge
 	transferCode := grpc.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/transfer_to_account.wasm"))
-	transferAbi := grpc.MakeArgsTransferToAccount(types.ToPublicKey(receipaddr), amount)
+	transferAbi := grpc.MakeArgsTransferToAccount(types.ToPublicKey(receipaddr), req.Amount)
 	paymentCode := grpc.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/standard_payment.wasm"))
 	paymentAbi := grpc.MakeArgsStandardPayment(new(big.Int).SetUint64(req.GasPrice))
 
 	// create the message
-	bankMsg := bank.NewMsgSend(senderaddr, receipaddr, coins)
-	eeMsg := types.NewMsgExecute([]byte{0}, senderaddr, senderaddr, transferCode, transferAbi, paymentCode, paymentAbi, req.GasPrice)
+	eeMsg := types.NewMsgTransfer(tokenowneraddr, senderaddr, receipaddr, transferCode, transferAbi, paymentCode, paymentAbi, req.GasPrice)
 	err = eeMsg.ValidateBasic()
 	if err != nil {
 		return rest.BaseReq{}, nil, err
 	}
 
-	return baseReq, []sdk.Msg{bankMsg, eeMsg}, nil
+	return baseReq, []sdk.Msg{eeMsg}, nil
 }
 
 type bondReq struct {

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -41,13 +41,14 @@ func TestRESTTransfer(t *testing.T) {
 	// Body
 	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	transReq := transferReq{
-		ChainID:          basereq.ChainID,
-		Memo:             basereq.Memo,
-		SenderAddress:    fromAddr,
-		Amount:           "100dummy",
-		GasPrice:         gas,
-		RecipientAddress: receipAddr,
-		Fee:              10_000_000,
+		ChainID:           basereq.ChainID,
+		Memo:              basereq.Memo,
+		TokenOwnerAddress: fromAddr,
+		SenderAddress:     fromAddr,
+		RecipientAddress:  receipAddr,
+		Amount:            20_000_000,
+		GasPrice:          gas,
+		Fee:               10_000_000,
 	}
 
 	// http.request

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -19,7 +19,7 @@ func NewHandler(k ExecutionLayerKeeper) sdk.Handler {
 		case types.MsgTransfer:
 			return handlerMsgTransfer(ctx, k, msg)
 		default:
-			errMsg := fmt.Sprintf("unrecognized bank message type: %T", msg)
+			errMsg := fmt.Sprintf("unrecognized execution layer messgae type: %T", msg)
 			return sdk.ErrUnknownRequest(errMsg).Result()
 		}
 	}

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -192,15 +192,16 @@ func (k ExecutionLayerKeeper) Execute(ctx sdk.Context,
 
 // GetQueryResult queries with whole parameters
 func (k ExecutionLayerKeeper) GetQueryResult(ctx sdk.Context,
-	stateHash []byte, keyType string, keyData string, path string) (state.Value, error) {
+	blockhash []byte, keyType string, keyData string, path string) (state.Value, error) {
 	arrPath := strings.Split(path, "/")
 
 	protocolVersion := k.MustGetProtocolVersion(ctx)
+	unitHash := k.GetUnitHashMap(ctx, blockhash)
 	keyDataBytes, err := toBytes(keyType, keyData)
 	if err != nil {
 		return state.Value{}, err
 	}
-	res, errstr := grpc.Query(k.client, stateHash, keyType, keyDataBytes, arrPath, &protocolVersion)
+	res, errstr := grpc.Query(k.client, unitHash.EEState, keyType, keyDataBytes, arrPath, &protocolVersion)
 	if errstr != "" {
 		return state.Value{}, fmt.Errorf(errstr)
 	}
@@ -230,9 +231,10 @@ func (k ExecutionLayerKeeper) GetQueryResultSimple(ctx sdk.Context,
 }
 
 // GetQueryBalanceResult queries with whole parameters
-func (k ExecutionLayerKeeper) GetQueryBalanceResult(ctx sdk.Context, stateHash []byte, address types.PublicKey) (string, error) {
+func (k ExecutionLayerKeeper) GetQueryBalanceResult(ctx sdk.Context, blockhash []byte, address types.PublicKey) (string, error) {
+	unitHash := k.GetUnitHashMap(ctx, blockhash)
 	protocolVersion := k.MustGetProtocolVersion(ctx)
-	res, err := grpc.QueryBalance(k.client, stateHash, address, &protocolVersion)
+	res, err := grpc.QueryBalance(k.client, unitHash.EEState, address, &protocolVersion)
 	if err != "" {
 		return "", fmt.Errorf(err)
 	}

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -131,15 +131,6 @@ func (k ExecutionLayerKeeper) Transfer(
 		toAddressAccountObject = k.AccountKeeper.NewAccountWithAddress(ctx, toAddress)
 	}
 
-	/*
-		If error occurs due to empty coin, assign coin:
-
-		err := toAddressAccountObject.SetCoins(amt)
-		if err != nil {
-			panic(err)
-		}
-	*/
-
 	// Parameter preparation
 	err := k.Execute(ctx, []byte{0}, fromAddress, tokenOwnerAccount, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)
 	if err != nil {

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -125,13 +125,7 @@ func (k ExecutionLayerKeeper) Transfer(
 	paymentAbi []byte,
 	gasPrice uint64) error {
 
-	// Recepient account existence check, if not, create one
-	toAddressAccountObject := k.AccountKeeper.GetAccount(ctx, toAddress)
-	if toAddressAccountObject == nil {
-		toAddressAccountObject = k.AccountKeeper.NewAccountWithAddress(ctx, toAddress)
-		k.AccountKeeper.SetAccount(ctx, toAddressAccountObject)
-	}
-
+	k.SetAccountIfNotExists(ctx, toAddress)
 	err := k.Execute(ctx, k.GetCurrentBlockHash(ctx), fromAddress, tokenOwnerAccount, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)
 	if err != nil {
 		return err
@@ -280,6 +274,16 @@ func (k ExecutionLayerKeeper) GetCurrentBlockHash(ctx sdk.Context) []byte {
 	blockHash := store.Get([]byte("currentblockhash"))
 
 	return blockHash
+}
+
+// SetAccountIfNotExists runs if network has no given account
+func (k ExecutionLayerKeeper) SetAccountIfNotExists(ctx sdk.Context, account sdk.AccAddress) {
+	// Recepient account existence check, if not, create one
+	toAddressAccountObject := k.AccountKeeper.GetAccount(ctx, account)
+	if toAddressAccountObject == nil {
+		toAddressAccountObject = k.AccountKeeper.NewAccountWithAddress(ctx, account)
+		k.AccountKeeper.SetAccount(ctx, toAddressAccountObject)
+	}
 }
 
 // SetCurrentBlockHash saves current block hash

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -129,6 +129,7 @@ func (k ExecutionLayerKeeper) Transfer(
 	toAddressAccountObject := k.AccountKeeper.GetAccount(ctx, toAddress)
 	if toAddressAccountObject == nil {
 		toAddressAccountObject = k.AccountKeeper.NewAccountWithAddress(ctx, toAddress)
+		k.AccountKeeper.SetAccount(ctx, toAddressAccountObject)
 	}
 
 	err := k.Execute(ctx, k.GetCurrentBlockHash(ctx), fromAddress, tokenOwnerAccount, transferCode, transferAbi, paymentCode, paymentAbi, gasPrice)

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -2,6 +2,7 @@ package executionlayer
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"path"
 	"reflect"
@@ -164,7 +165,7 @@ func TestTransfer(t *testing.T) {
 		GenesisAccountAddress,
 		RecipientAccountAddress,
 		util.LoadWasmFile(path.Join(contractPath, transferWasm)),
-		util.MakeArgsTransferToAccount(types.ToPublicKey(RecipientAccountAddress), 200000000),
+		util.MakeArgsTransferToAccount(types.ToPublicKey(RecipientAccountAddress), 100000000),
 		util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm)),
 		util.MakeArgsStandardPayment(new(big.Int).SetUint64(200000000)),
 		uint64(200000000),
@@ -183,8 +184,13 @@ func TestTransfer(t *testing.T) {
 	res, err := input.elk.GetQueryBalanceResultSimple(input.ctx, types.ToPublicKey(RecipientAccountAddress))
 	queriedRes, _ := strconv.Atoi(res)
 
-	assert.Equal(t, queriedRes, 200000000)
+	assert.Equal(t, queriedRes, 100000000)
 	assert.Equal(t, err, nil)
+
+	res2, err := input.elk.GetQueryBalanceResultSimple(input.ctx, types.ToPublicKey(GenesisAccountAddress))
+	queriedRes2, _ := strconv.Atoi(res2)
+	fmt.Println(queriedRes)
+	fmt.Println(queriedRes2)
 }
 
 func TestMarsahlAndUnMarshal(t *testing.T) {

--- a/x/executionlayer/module.go
+++ b/x/executionlayer/module.go
@@ -4,15 +4,14 @@ import (
 	"encoding/json"
 
 	"github.com/gorilla/mux"
-	"github.com/spf13/cobra"
 	abci "github.com/hdac-io/tendermint/abci/types"
+	"github.com/spf13/cobra"
 
 	"github.com/hdac-io/friday/client/context"
 	"github.com/hdac-io/friday/codec"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/types/module"
 
-	"github.com/hdac-io/friday/x/executionlayer/client/cli"
 	"github.com/hdac-io/friday/x/executionlayer/client/rest"
 	"github.com/hdac-io/friday/x/executionlayer/types"
 )
@@ -57,12 +56,12 @@ func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router
 
 // get the root tx command of this module
 func (AppModuleBasic) GetTxCmd(cdc *codec.Codec) *cobra.Command {
-	return cli.GetExecutionLayerTxCmd(cdc)
+	return nil
 }
 
 // get the root query command of this module
 func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
-	return cli.GetExecutionLayerQueryCmd(cdc)
+	return nil
 }
 
 //___________________________

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -41,9 +41,9 @@ func queryEEDetail(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, errmsg := keeper.GetQueryResult(ctx, param.StateHash, param.KeyType, param.KeyData, param.Path)
-	if errmsg != nil {
-		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, errmsg.Error())
+	val, err := keeper.GetQueryResult(ctx, param.StateHash, param.KeyType, param.KeyData, param.Path)
+	if err != nil {
+		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, err.Error())
 	}
 
 	qryvalue := QueryExecutionLayerResp{
@@ -61,9 +61,9 @@ func queryEE(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Execu
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
 	}
 
-	val, errmsg := keeper.GetQueryResultSimple(ctx, param.KeyType, param.KeyData, param.Path)
-	if errmsg != nil {
-		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, errmsg.Error())
+	val, err := keeper.GetQueryResultSimple(ctx, param.KeyType, param.KeyData, param.Path)
+	if err != nil {
+		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, err.Error())
 	}
 
 	qryvalue := QueryExecutionLayerResp{

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -26,13 +26,15 @@ const (
 )
 
 var (
-	GenesisAccountAddress, _ = sdk.AccAddressFromBech32("friday1dl2cjlfpmc9hcyd4rxts047tze87s0gxmzqx70")
-	contractPath             = os.ExpandEnv("$HOME/.nodef/contracts")
-	mintInstallWasm          = "mint_install.wasm"
-	posInstallWasm           = "pos_install.wasm"
-	standardPaymentWasm      = "standard_payment.wasm"
-	counterDefineWasm        = "counter_define.wasm"
-	counterCallWasm          = "counter_call.wasm"
+	GenesisAccountAddress, _   = sdk.AccAddressFromBech32("friday1dl2cjlfpmc9hcyd4rxts047tze87s0gxmzqx70")
+	RecipientAccountAddress, _ = sdk.AccAddressFromBech32("friday1y2dx0evs5k6hxuhfrfdmm7wcwsrqr073htghpv")
+	contractPath               = os.ExpandEnv("$HOME/.nodef/contracts")
+	mintInstallWasm            = "mint_install.wasm"
+	posInstallWasm             = "pos_install.wasm"
+	standardPaymentWasm        = "standard_payment.wasm"
+	counterDefineWasm          = "counter_define.wasm"
+	counterCallWasm            = "counter_call.wasm"
+	transferWasm               = "transfer_to_account.wasm"
 )
 
 type testInput struct {

--- a/x/executionlayer/types/codec.go
+++ b/x/executionlayer/types/codec.go
@@ -15,4 +15,5 @@ func init() {
 // RegisterCodec registers concrete types on the Amino codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgExecute{}, "executionengine/Execute", nil)
+	cdc.RegisterConcrete(MsgTransfer{}, "executionengine/Transfer", nil)
 }

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -62,3 +62,58 @@ func (msg MsgExecute) GetSignBytes() []byte {
 func (msg MsgExecute) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.ExecAccount}
 }
+
+// MsgTransfer for sending deploy to execution engine
+type MsgTransfer struct {
+	TokenOwnerAccount sdk.AccAddress `json:"token_owner_account"`
+	FromAccount       sdk.AccAddress `json:"from_account"`
+	ToAccount         sdk.AccAddress `json:"to_account"`
+	TransferCode      []byte         `json:"transfer_code"`
+	TransferArgs      []byte         `json:"transfer_args"`
+	PaymentCode       []byte         `json:"payment_code"`
+	PaymentArgs       []byte         `json:"payment_args"`
+	GasPrice          uint64         `json:"gas_price"`
+}
+
+// NewMsgTransfer is a constructor function for MsgSetName
+func NewMsgTransfer(
+	tokenOwnerAccount sdk.AccAddress,
+	fromAccount, toAccount sdk.AccAddress,
+	transferCode, transferArgs, paymentCode, paymentArgs []byte,
+	gasPrice uint64,
+) MsgTransfer {
+	return MsgTransfer{
+		TokenOwnerAccount: tokenOwnerAccount,
+		FromAccount:       fromAccount,
+		ToAccount:         toAccount,
+		TransferCode:      transferCode,
+		TransferArgs:      transferArgs,
+		PaymentCode:       paymentCode,
+		PaymentArgs:       paymentArgs,
+		GasPrice:          gasPrice,
+	}
+}
+
+// Route should return the name of the module
+func (msg MsgTransfer) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgTransfer) Type() string { return "executionengine" }
+
+// ValidateBasic runs stateless checks on the message
+func (msg MsgTransfer) ValidateBasic() sdk.Error {
+	if msg.FromAccount.Equals(sdk.AccAddress("")) || msg.TokenOwnerAccount.Equals(sdk.AccAddress("")) {
+		return sdk.ErrUnknownRequest("Address cannot be empty")
+	}
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgTransfer) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgTransfer) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.FromAccount}
+}

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -1,0 +1,33 @@
+package executionlayer
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	sdk "github.com/hdac-io/friday/types"
+	"github.com/hdac-io/friday/x/executionlayer/types"
+)
+
+// TODO: change KeyType from string to typed enum.
+func toBytes(keyType string, key string) ([]byte, error) {
+	var bytes []byte
+	var err error = nil
+
+	switch keyType {
+	case "address":
+		bech32addr, err := sdk.AccAddressFromBech32(key)
+		if err != nil {
+			return nil, err
+		}
+		bytes = types.ToPublicKey(bech32addr)
+	case "uref", "local", "hash":
+		bytes, err = hex.DecodeString(key)
+	default:
+		err = fmt.Errorf("Unknown QueryKey type: %v", keyType)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}


### PR DESCRIPTION
* Detaching bank module from EE
  * Add 'create account' logic if recipient account doesn't exist
  * Inserted `token_owner_address` for later use in request message
  * Restore transfer logic inside of keeper
  * `makeEETransferMsg` in bank account still remains in case of emergency