### PR TITLE
Support to execution engine v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Password to sign with 'elsa': # input your password
 --from $(clif keys show elsa -a) \
 --validator fridayvaloper19rxdgfn3grqgwc6zhyeljmyas3tsawn64dsges \
 --amount 1000000 \
---fee 10000000 \
+--fee 100000000 \
 --gas-price 30000000
 
 confirm transaction before signing and broadcasting [y/N]: y
@@ -151,7 +151,7 @@ Password to sign with 'elsa':
 --from $(clif keys show elsa -a) \
 --validator fridayvaloper19rxdgfn3grqgwc6zhyeljmyas3tsawn64dsges \
 --amount 1000000 \
---fee 10000000 \
+--fee 100000000 \
 --gas-price 30000000
 
 confirm transaction before signing and broadcasting [y/N]: y
@@ -198,9 +198,10 @@ seeds = "" -> "<genesis node's ID>@<genesis node's IP>:26656"
 ...
 ```
 * replace `~/.nodef/config/genesis.json` to genesis node's one what you saved above.
+* copy `~/.nodef/config/manifest.toml` to manifest node's one what you saved above.
 
 ### Running validator
-* run this on another machine
+* run on this fullly synchronized node
 * create a wallet key
 ```sh
 clif keys add bryan # select password
@@ -240,7 +241,7 @@ clif executionlayer bond \
 --from friday19rxdgfn3grqgwc6zhyeljmyas3tsawn6qe0quc \
 --validator fridayvaloper19rxdgfn3grqgwc6zhyeljmyas3tsawn64dsges \
 --amount 1000000 \
---fee 10000000 \
+--fee 100000000 \
 --gas-price 30000000 \
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20191204072007-3ca563b18909
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20200107075212-e3e40973f879
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20191204072007-3ca563b18909 h1:AESBqLrkDN65Gbd/Fc0FEW14V96QSuTe5vHazLqBJ+Q=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20191204072007-3ca563b18909/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20200107075212-e3e40973f879 h1:1FE1E98qB9OJ/jjL/pbUxiOcI2sVhnqxeVDDxV/kcA0=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.0.0-20200107075212-e3e40973f879/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -7,7 +7,7 @@ if [ ${PWD##*/} != "friday" ]; then
   exit 1
 fi
 
-CASPERLABS_TARGET_TAG="v0.9.0"
+CASPERLABS_TARGET_TAG="v0.10.0"
 if [ ! -d "CasperLabs/.git" ]; then
   git clone --single-branch --branch $CASPERLABS_TARGET_TAG https://github.com/CasperLabs/CasperLabs.git
 fi

--- a/tests/resources/executionlayer/genesis/manifest.toml
+++ b/tests/resources/executionlayer/genesis/manifest.toml
@@ -12,6 +12,11 @@ mint-code-path = "mint_install.wasm"
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos_install.wasm"
 
+[deploys]
+# 1 day
+max-ttl-millis = 1
+max-dependencies = 2
+
 [wasm-costs]
 # Default opcode cost
 regular = 1

--- a/x/executionlayer/configuration/chainspec.go
+++ b/x/executionlayer/configuration/chainspec.go
@@ -37,6 +37,16 @@ func ParseGenesisChainSpec(chainSpecPath string) (*types.GenesisConf, error) {
 		return nil, err
 	}
 
+	// Get deploys
+	subTree = tree.Get("deploys").(*toml.Tree)
+	if subTree == nil {
+		return nil, types.ErrTomlParse(types.DefaultCodespace, "deploys")
+	}
+	err = subTree.Unmarshal(&genesisConf.DeployConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &genesisConf, nil
 }
 

--- a/x/executionlayer/configuration/chainspec_test.go
+++ b/x/executionlayer/configuration/chainspec_test.go
@@ -35,6 +35,10 @@ func genesisConfigMock() types.GenesisConf {
 			OpcodesMultiplier: 9,
 			OpcodesDivisor:    10,
 		},
+		DeployConfig: types.DeployConfig{
+			MaxTtlMillis:    1,
+			MaxDependencies: 2,
+		},
 	}
 }
 
@@ -50,6 +54,10 @@ func TestParseGenesisChainSpecBasic(t *testing.T) {
 
 	if !reflect.DeepEqual(expected.WasmCosts, got.WasmCosts) {
 		t.Errorf("Bad WasmCosts, expected %v, got %v", expected.WasmCosts, got.WasmCosts)
+	}
+
+	if !reflect.DeepEqual(expected.DeployConfig, got.DeployConfig) {
+		t.Errorf("Bad DeployConfig, expected %v, got %v", expected.DeployConfig, got.DeployConfig)
 	}
 }
 

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hdac-io/friday/x/executionlayer/types"
 )
 
-// InitGenesis sets an execution\layer configuration for genesis.
+// InitGenesis sets an executionlayer configuration for genesis.
 func InitGenesis(
 	ctx sdk.Context, keeper ExecutionLayerKeeper, data types.GenesisState) {
 	genesisConfig, err := types.ToChainSpecGenesisConfig(data)

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -1,7 +1,6 @@
 package executionlayer
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
@@ -11,7 +10,7 @@ import (
 	"github.com/hdac-io/friday/x/executionlayer/types"
 )
 
-// InitGenesis sets an executionlayer configuration for genesis.
+// InitGenesis sets an execution\layer configuration for genesis.
 func InitGenesis(
 	ctx sdk.Context, keeper ExecutionLayerKeeper, data types.GenesisState) {
 	genesisConfig, err := types.ToChainSpecGenesisConfig(data)
@@ -19,16 +18,7 @@ func InitGenesis(
 		panic(err)
 	}
 
-	isMintValid, _ := grpc.Validate(
-		keeper.client, genesisConfig.GetMintInstaller(), genesisConfig.GetProtocolVersion())
-	isPosValid, _ := grpc.Validate(
-		keeper.client, genesisConfig.GetPosInstaller(), genesisConfig.GetProtocolVersion())
-
-	if !isMintValid || !isPosValid {
-		panic(fmt.Errorf("Bad system contracts. mint: %v, pos: %v", isMintValid, isPosValid))
-	}
-
-	response, err := grpc.RunGenesis(keeper.client, genesisConfig)
+	response, err := keeper.client.RunGenesis(ctx.Context(), genesisConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/x/executionlayer/resources/manifest.toml
+++ b/x/executionlayer/resources/manifest.toml
@@ -4,7 +4,7 @@
 # generator used in execution engine for computing genesis post-state.
 timestamp = 0
 
-# semver.
+# Later will be replaced by semver.
 protocol-version = "1.0.0"
 
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
@@ -12,6 +12,11 @@ mint-code-path = "../contracts/mint_install.wasm"
 
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "../contracts/pos_install.wasm"
+
+[deploys]
+# 1 day
+max-ttl-millis = 86400000
+max-dependencies = 10
 
 [wasm-costs]
 # Default opcode cost

--- a/x/executionlayer/types/errors.go
+++ b/x/executionlayer/types/errors.go
@@ -15,6 +15,9 @@ const (
 	CodeInvalidDelegation    sdk.CodeType = 202
 	CodeInvalidInput         sdk.CodeType = 203
 	CodeInvalidAddress		 sdk.CodeType = sdk.CodeInvalidAddress
+	CodeGRpcExecuteMissingParent sdk.CodeType = 301
+	CodeGRpcExecuteDeployGasError sdk.CodeType = 302
+	CodeGRpcExecuteDeployExecError sdk.CodeType = 302
 )
 
 // ErrPublicKeyDecode is an error
@@ -60,4 +63,16 @@ func ErrBadDelegationAddr(codespace sdk.CodespaceType) sdk.Error {
 
 func ErrBadDelegationAmount(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "amount must be > 0")
+}
+
+func ErrGRpcExecuteMissingParent(codespace sdk.CodespaceType, hash string) sdk.Error {
+	return sdk.NewError(codespace, CodeGRpcExecuteMissingParent, "execution engine - missing parent state %s", hash)
+}
+
+func ErrGRpcExecuteDeployGasError(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeGRpcExecuteDeployGasError, "execution engine - deploy error - gas")
+}
+
+func ErrGRpcExecuteDeployExecError(codespace sdk.CodespaceType, msg string) sdk.Error {
+	return sdk.NewError(codespace, CodeGRpcExecuteDeployExecError, "execution engine - deploy error - execute : ", msg)
 }

--- a/x/executionlayer/types/genesis.go
+++ b/x/executionlayer/types/genesis.go
@@ -1,11 +1,13 @@
 package types
 
 import (
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 )
 
 // GenesisState : the executionlayer state that must be provided at genesis.
@@ -57,6 +59,11 @@ type DeployConfig struct {
 	MaxDependencies uint32 `json:"max-dependencies" toml:"max-dependencies"`
 }
 
+const (
+	mintCodePath = "$HOME/.nodef/contracts/mint_install.wasm"
+	posCodePath  = "$HOME/.nodef/contracts/pos_install.wasm"
+)
+
 // NewGenesisState creates a new genesis state.
 func NewGenesisState(genesisConf GenesisConf, accounts []Account, chainName string) GenesisState {
 	return GenesisState{GenesisConf: genesisConf, Accounts: accounts, ChainName: chainName}
@@ -67,8 +74,8 @@ func DefaultGenesisState() GenesisState {
 	genesisConf := GenesisConf{
 		Genesis: Genesis{
 			Timestamp:       0,
-			MintWasm:        DefaultMintWasm,
-			PosWasm:         DefaultPosWasm,
+			MintWasm:        util.LoadWasmFile(os.ExpandEnv(mintCodePath)),
+			PosWasm:         util.LoadWasmFile(os.ExpandEnv(posCodePath)),
 			ProtocolVersion: "1.0.0",
 		},
 		WasmCosts: WasmCosts{
@@ -84,7 +91,7 @@ func DefaultGenesisState() GenesisState {
 			OpcodesDivisor:    8,
 		},
 		DeployConfig: DeployConfig{
-			MaxTtlMillis: 86400000,
+			MaxTtlMillis:    86400000,
 			MaxDependencies: 10,
 		},
 	}

--- a/x/executionlayer/types/genesis_test.go
+++ b/x/executionlayer/types/genesis_test.go
@@ -8,11 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	mintCodePath = "$HOME/.nodef/contracts/mint_install.wasm"
-	posCodePath  = "$HOME/.nodef/contracts/pos_install.wasm"
-)
-
 func TestToProtocolVersion(t *testing.T) {
 	// empty string
 	got, err := ToProtocolVersion("")


### PR DESCRIPTION
- Version up v0.10.0
-- add to deploy config in genesis
-- remove wasm validate function
-- change to using the system contract default path just like any other contract. (need to change when creating integrated test later)

- removed utility dependencies when execute grpc error handling to effectively handle multiple deploys
- handling wasm execute error