### PR TITLE
feat: remove to ValAddress

### DIFF
--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -311,7 +311,7 @@ func BuildCreateValidatorMsg(cliCtx context.CLIContext) (sdk.Msg, error) {
 		viper.GetString(FlagDetails),
 	)
 
-	msg := types.NewMsgCreateValidator(sdk.ValAddress(valAddr), valPubKey, consPubKey, description)
+	msg := types.NewMsgCreateValidator(sdk.AccAddress(valAddr), valPubKey, consPubKey, description)
 
 	return msg, nil
 }

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -135,14 +135,14 @@ func (msg MsgTransfer) GetSigners() []sdk.AccAddress {
 //______________________________________________________________________
 // MsgCreateValidator - struct for bonding transactions
 type MsgCreateValidator struct {
-	ValidatorAddress sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
+	ValidatorAddress sdk.AccAddress `json:"validator_address" yaml:"validator_address"`
 	ValidatorPubKey  crypto.PubKey  `json:"validator_pubkey" yaml:"validator_pubkey"`
 	ConsPubKey       crypto.PubKey  `json:"cons_pubkey" yaml:"cons_pubkey"`
 	Description      Description    `json:"description" yaml:"description"`
 }
 
 type msgCreateValidatorJSON struct {
-	ValidatorAddress sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
+	ValidatorAddress sdk.AccAddress `json:"validator_address" yaml:"validator_address"`
 	ValidatorPubKey  string         `json:"validator_pubkey" yaml:"validator_pubkey"`
 	ConsPubKey       string         `json:"cons_pubkey" yaml:"cons_pubkey"`
 	Description      Description    `json:"description" yaml:"description"`
@@ -150,7 +150,7 @@ type msgCreateValidatorJSON struct {
 
 // Default way to create validator. Delegator address and validator address are the same
 func NewMsgCreateValidator(
-	valAddress sdk.ValAddress,
+	valAddress sdk.AccAddress,
 	valPubKey crypto.PubKey,
 	consPubKey crypto.PubKey,
 	description Description,

--- a/x/executionlayer/types/types_test.go
+++ b/x/executionlayer/types/types_test.go
@@ -14,7 +14,7 @@ func TestNewPublicKeyFromAddress(t *testing.T) {
 	byteAddr, err := sdk.GetFromBech32(bech32ValAddr, "fridayvaloper")
 	require.Nil(t, err)
 
-	valAddr := sdk.ValAddress(byteAddr)
+	valAddr := sdk.AccAddress(byteAddr)
 	pubkey := ToPublicKey(valAddr)
 	require.Equal(t, len(pubkey), 32)
 }

--- a/x/executionlayer/types/validator_test.go
+++ b/x/executionlayer/types/validator_test.go
@@ -8,11 +8,6 @@ import (
 )
 
 func TestValidatorTestEquivalent(t *testing.T) {
-	accAddr := "friday19rxdgfn3grqgwc6zhyeljmyas3tsawn6qe0quc"
-	acc, _ := sdk.AccAddressFromBech32(accAddr)
-	valAddr := sdk.ValAddress(acc)
-
-	require.Equal(t, "fridayvaloper19rxdgfn3grqgwc6zhyeljmyas3tsawn64dsges", valAddr.String())
 	valPubKey, _ := sdk.GetValPubKeyBech32("fridayvaloperpub1addwnpepqfaxrvy4f95duln3t6vvtd0qd0sdpwfsn3fh9snpnq06w25qualj6vczad0")
 	eeAddress, _ := sdk.GetEEAddressFromCryptoPubkey(valPubKey)
 


### PR DESCRIPTION
Do not use ValAddress in friday.

Feat:
- Need to change AccAddress type.
- clif will be used accaddress or nameservice. (do not need to use pubkey)