### PR TITLE
feat: add to edit-validator

### DIFF
--- a/x/executionlayer/abci.go
+++ b/x/executionlayer/abci.go
@@ -24,15 +24,15 @@ func EndBloker(ctx sdk.Context, k ExecutionLayerKeeper) []abci.ValidatorUpdate {
 	validators := k.GetAllValidators(ctx)
 
 	resultbonds := ctx.CandidateBlock().Bonds
-	resultBondsMap := make(map[string]*ipc.Bond)
-	for _, bond := range resultbonds {
-		resultBondsMap[string(bond.GetValidatorPublicKey())] = bond
-	}
-
 	if len(resultbonds) > 0 {
+		resultBondsMap := make(map[string]*ipc.Bond)
+		for _, bond := range resultbonds {
+			resultBondsMap[string(bond.GetValidatorPublicKey())] = bond
+		}
+
 		for _, validator := range validators {
 			var power string
-			resultBond, found := resultBondsMap[string(validator.OperatorAddress.Bytes())]
+			resultBond, found := resultBondsMap[string(validator.OperatorAddress.ToEEAddress())]
 			if found {
 				if validator.Stake == resultBond.GetStake().GetValue() {
 					continue

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -36,4 +36,5 @@ type (
 	QueryExecutionLayerDetail = types.QueryExecutionLayerDetail
 	QueryGetBalance           = types.QueryGetBalance
 	QueryGetBalanceDetail     = types.QueryGetBalanceDetail
+	QueryValidatorParams      = types.QueryValidatorParams
 )

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -29,6 +29,7 @@ type (
 	MsgBond                   = types.MsgBond
 	MsgUnBond                 = types.MsgUnBond
 	MsgCreateValidator        = types.MsgCreateValidator
+	MsgEditValidator          = types.MsgEditValidator
 	QueryExecutionLayer       = types.QueryExecutionLayer
 	UnitHashMap               = types.UnitHashMap
 	QueryExecutionLayerResp   = types.QueryExecutionLayerResp

--- a/x/executionlayer/client/cli/query.go
+++ b/x/executionlayer/client/cli/query.go
@@ -216,27 +216,38 @@ func GetCmdQueryValidator(cdc *codec.Codec) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
 				}
+			}
+
+			if addr.Empty() {
+				res, _, err := cliCtx.Query(fmt.Sprintf("custom/%s/queryallvalidator", types.ModuleName))
+				if err != nil {
+					fmt.Printf("could not resolve")
+					return nil
+				}
+
+				var out types.Validators
+				cdc.MustUnmarshalJSON(res, &out)
+
+				return cliCtx.PrintOutput(out)
 			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+				queryData := types.NewQueryValidatorParams(addr)
+				bz := cdc.MustMarshalJSON(queryData)
+
+				res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryvalidator", types.ModuleName), bz)
+				if err != nil {
+					fmt.Printf("could not resolve data - %s\n", addr.String())
+					return nil
+				}
+
+				if len(res) == 0 {
+					return fmt.Errorf("No validator found with address %s", addr)
+				}
+
+				var out types.Validator
+				cdc.MustUnmarshalJSON(res, &out)
+
+				return cliCtx.PrintOutput(out)
 			}
-
-			queryData := types.NewQueryValidatorParams(addr)
-			bz := cdc.MustMarshalJSON(queryData)
-
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryvalidator", types.ModuleName), bz)
-			if err != nil {
-				fmt.Printf("could not resolve data - %s\n", addr.String())
-				return nil
-			}
-
-			if len(res) == 0 {
-				return fmt.Errorf("No validator found with address %s", addr)
-			}
-
-			var out types.Validator
-			cdc.MustUnmarshalJSON(res, &out)
-
-			return cliCtx.PrintOutput(out)
 		},
 	}
 
@@ -246,27 +257,4 @@ func GetCmdQueryValidator(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String(FlagNickname, "", "Nickname (Readable ID)")
 
 	return cmd
-}
-
-// // GetCmdQueryValidators implements the query all validators command.
-func GetCmdQueryValidators(cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "validators",
-		Short: "Query for all validators",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-
-			res, _, err := cliCtx.Query(fmt.Sprintf("custom/%s/queryallvalidator", types.ModuleName))
-			if err != nil {
-				fmt.Printf("could not resolve")
-				return nil
-			}
-
-			var out types.Validators
-			cdc.MustUnmarshalJSON(res, &out)
-
-			return cliCtx.PrintOutput(out)
-		},
-	}
 }

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -28,7 +28,6 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		GetCmdQueryBalance(cdc),
 		GetCmdQuery(cdc),
 		GetCmdQueryValidator(cdc),
-		GetCmdQueryValidators(cdc),
 	)...)
 	return hdacCustomTxCmd
 }

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -22,6 +22,7 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		GetCmdBonding(cdc),
 		GetCmdUnbonding(cdc),
 		GetCmdCreateValidator(cdc),
+		GetCmdEditValidator(cdc),
 
 		// Query
 		GetCmdQueryBalance(cdc),

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -27,6 +27,8 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		// Query
 		GetCmdQueryBalance(cdc),
 		GetCmdQuery(cdc),
+		GetCmdQueryValidator(cdc),
+		GetCmdQueryValidators(cdc),
 	)...)
 	return hdacCustomTxCmd
 }

--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -158,3 +158,25 @@ func getBalanceQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 
 	return bz, nil
 }
+
+func getValidatorQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) ([]byte, error) {
+	vars := r.URL.Query()
+	strAddr := vars.Get("address")
+
+	if strAddr == "" {
+		return []byte{}, nil
+	}
+
+	addr, err := cliutil.GetAddress(cliCtx.Codec, cliCtx, strAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	queryData := types.QueryValidatorParams{
+		ValidatorAddr: addr,
+	}
+
+	bz := cliCtx.Codec.MustMarshalJSON(queryData)
+
+	return bz, nil
+}

--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -160,15 +160,12 @@ func getBalanceQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 }
 
 type createValidatorReq struct {
-	ChainID                    string `json:"chain_id"`
-	ValidatorAddressOrNickName string `json:"validator_address_or_nickname"`
-	ConsPubKey                 string `json:"cons_pub_key"`
-	Moniker                    string `json:"moniker"`
-	Identity                   string `json:"identity"`
-	Website                    string `json:"website"`
-	Details                    string `json:"details"`
-	Gas                        uint64 `json:"gas"`
-	Memo                       string `json:"memo"`
+	ChainID                    string            `json:"chain_id"`
+	ValidatorAddressOrNickName string            `json:"validator_address_or_nickname"`
+	ConsPubKey                 string            `json:"cons_pub_key"`
+	Description                types.Description `json:"description"`
+	Gas                        uint64            `json:"gas"`
+	Memo                       string            `json:"memo"`
 }
 
 func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) (rest.BaseReq, []sdk.Msg, error) {
@@ -206,7 +203,7 @@ func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext,
 	}
 
 	// create the message
-	msg := types.NewMsgCreateValidator(valAddr, consPubKey, types.NewDescription(req.Moniker, req.Identity, req.Website, req.Details))
+	msg := types.NewMsgCreateValidator(valAddr, consPubKey, req.Description)
 	err = msg.ValidateBasic()
 	if err != nil {
 		return rest.BaseReq{}, nil, err
@@ -216,14 +213,11 @@ func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext,
 }
 
 type editValidatorReq struct {
-	ChainID                    string `json:"chain_id"`
-	ValidatorAddressOrNickName string `json:"validator_address_or_nickname"`
-	Moniker                    string `json:"moniker"`
-	Identity                   string `json:"identity"`
-	Website                    string `json:"website"`
-	Details                    string `json:"details"`
-	Gas                        uint64 `json:"gas"`
-	Memo                       string `json:"memo"`
+	ChainID                    string            `json:"chain_id"`
+	ValidatorAddressOrNickName string            `json:"validator_address_or_nickname"`
+	Description                types.Description `json:"description"`
+	Gas                        uint64            `json:"gas"`
+	Memo                       string            `json:"memo"`
 }
 
 func editValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) (rest.BaseReq, []sdk.Msg, error) {
@@ -255,7 +249,7 @@ func editValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r
 	}
 
 	// create the message
-	msg := types.NewMsgEditValidator(valAddr, types.NewDescription(req.Moniker, req.Identity, req.Website, req.Details))
+	msg := types.NewMsgEditValidator(valAddr, req.Description)
 	err = msg.ValidateBasic()
 	if err != nil {
 		return rest.BaseReq{}, nil, err

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -121,6 +121,78 @@ func TestRESTBalance(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }
+
+func TestRESTGetValidator(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/validator?address=%s", types.ModuleName, fromAddr), nil)
+	res, err := getValidatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetValidators(t *testing.T) {
+	_, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/validator", types.ModuleName), nil)
+	res, err := getValidatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTCreateValidator(t *testing.T) {
+	fromAddr, _, writer, clictx, basereq := prepare()
+
+	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
+	createValidatorReq := createValidatorReq{
+		ChainID:                    basereq.ChainID,
+		ValidatorAddressOrNickName: fromAddr,
+		ConsPubKey:                 "fridayvalconspub16jrl8jvqq9k957nfd43n2dnyxc6nsazpgf5yuwtzfe6kku63ga6nvtmcdeg92vj4gy4kkd62vd69vvnhx935w5zpw9ex7733tft8we6evemzke66xv4ks56gfdvx66ndfye5x5z9fs6j74z6g3u4zdzd0p8hw6mr24k8wjzx0ghhz5z8vdm92vjs2e8xwdn5xpvxu56fvejnj7t6wsens5gwxlen9",
+		Moniker:                    "moniker",
+		Identity:                   "identity",
+		Website:                    "https://test.io",
+		Details:                    "details",
+		Gas:                        gas,
+		Memo:                       basereq.Memo,
+	}
+
+	body := clictx.Codec.MustMarshalJSON(createValidatorReq)
+	req := mustNewRequest(t, "POST", fmt.Sprintf("/%s/validator", types.ModuleName), bytes.NewReader((body)))
+
+	outputCreateValidatorReq, msgs, err := createValidatorMsgCreator(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputCreateValidatorReq, basereq)
+	require.NotNil(t, msgs)
+}
+
+func TestRESTEditValidator(t *testing.T) {
+	fromAddr, _, writer, clictx, basereq := prepare()
+
+	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
+	editValidatorReq := editValidatorReq{
+		ChainID:                    basereq.ChainID,
+		ValidatorAddressOrNickName: fromAddr,
+		Moniker:                    "edit-moniker",
+		Identity:                   "edit-identity",
+		Website:                    "https://edit.test.io",
+		Details:                    "edit",
+		Gas:                        gas,
+		Memo:                       basereq.Memo,
+	}
+
+	body := clictx.Codec.MustMarshalJSON(editValidatorReq)
+	req := mustNewRequest(t, "PUT", fmt.Sprintf("/%s/validator", types.ModuleName), bytes.NewReader((body)))
+
+	outputEditValidatorReq, msgs, err := editValidatorMsgCreator(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputEditValidatorReq, basereq)
+	require.NotNil(t, msgs)
+}
+
 func mustNewRequest(t *testing.T, method, url string, body io.Reader) *http.Request {
 	req, err := http.NewRequest(method, url, body)
 	require.NoError(t, err)

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -150,10 +150,7 @@ func TestRESTCreateValidator(t *testing.T) {
 		ChainID:                    basereq.ChainID,
 		ValidatorAddressOrNickName: fromAddr,
 		ConsPubKey:                 "fridayvalconspub16jrl8jvqq9k957nfd43n2dnyxc6nsazpgf5yuwtzfe6kku63ga6nvtmcdeg92vj4gy4kkd62vd69vvnhx935w5zpw9ex7733tft8we6evemzke66xv4ks56gfdvx66ndfye5x5z9fs6j74z6g3u4zdzd0p8hw6mr24k8wjzx0ghhz5z8vdm92vjs2e8xwdn5xpvxu56fvejnj7t6wsens5gwxlen9",
-		Moniker:                    "moniker",
-		Identity:                   "identity",
-		Website:                    "https://test.io",
-		Details:                    "details",
+		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
 		Gas:                        gas,
 		Memo:                       basereq.Memo,
 	}
@@ -175,10 +172,7 @@ func TestRESTEditValidator(t *testing.T) {
 	editValidatorReq := editValidatorReq{
 		ChainID:                    basereq.ChainID,
 		ValidatorAddressOrNickName: fromAddr,
-		Moniker:                    "edit-moniker",
-		Identity:                   "edit-identity",
-		Website:                    "https://edit.test.io",
-		Details:                    "edit",
+		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
 		Gas:                        gas,
 		Memo:                       basereq.Memo,
 	}

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -19,7 +19,9 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/bond", storeName), bondHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/unbond", storeName), unbondHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/balance", storeName), getBalanceHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), validatorHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), getValidatorHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), createValidatorHandler(cliCtx)).Methods("PUT")
+	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), editValidatorHandler(cliCtx)).Methods("POST")
 }
 
 func transferHandler(cliCtx context.CLIContext) http.HandlerFunc {
@@ -72,7 +74,29 @@ func getBalanceHandler(cliCtx context.CLIContext, storeName string) http.Handler
 	}
 }
 
-func validatorHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+func createValidatorHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		baseReq, msgs, err := createValidatorMsgCreator(w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, msgs)
+	}
+}
+
+func editValidatorHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		baseReq, msgs, err := editValidatorMsgCreator(w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, msgs)
+	}
+}
+
+func getValidatorHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		bz, err := getValidatorQuerying(w, cliCtx, r)
 		if err != nil {

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 
@@ -19,9 +18,9 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/bond", storeName), bondHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/unbond", storeName), unbondHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/balance", storeName), getBalanceHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), getValidatorHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), createValidatorHandler(cliCtx)).Methods("POST")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), editValidatorHandler(cliCtx)).Methods("PUT")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), getValidatorHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), createValidatorHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), editValidatorHandler(cliCtx)).Methods("PUT")
 }
 
 func transferHandler(cliCtx context.CLIContext) http.HandlerFunc {
@@ -105,7 +104,7 @@ func getValidatorHandler(cliCtx context.CLIContext, storeName string) http.Handl
 		}
 
 		var res []byte
-		if bytes.Equal(bz, []byte{}) {
+		if len(bz) == 0 {
 			res, _, err = cliCtx.Query(fmt.Sprintf("custom/%s/queryallvalidator", storeName))
 		} else {
 			res, _, err = cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryvalidator", types.ModuleName), bz)

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -20,8 +20,8 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/unbond", storeName), unbondHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/balance", storeName), getBalanceHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), getValidatorHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), createValidatorHandler(cliCtx)).Methods("PUT")
-	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), editValidatorHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), createValidatorHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/validator", storeName), editValidatorHandler(cliCtx)).Methods("PUT")
 }
 
 func transferHandler(cliCtx context.CLIContext) http.HandlerFunc {

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -232,9 +232,9 @@ func (k ExecutionLayerKeeper) SetAccountIfNotExists(ctx sdk.Context, addr sdk.Ac
 
 // -----------------------------------------------------------------------------------------------------------
 
-func (k ExecutionLayerKeeper) GetValidator(ctx sdk.Context, eeAddress sdk.EEAddress) (validator types.Validator, found bool) {
+func (k ExecutionLayerKeeper) GetValidator(ctx sdk.Context, accAddress sdk.AccAddress) (validator types.Validator, found bool) {
 	store := ctx.KVStore(k.HashMapStoreKey)
-	validatorBytes := store.Get(types.GetValidatorKey(eeAddress))
+	validatorBytes := store.Get(types.GetValidatorKey(accAddress))
 	if validatorBytes == nil {
 		return validator, false
 	}
@@ -243,46 +243,46 @@ func (k ExecutionLayerKeeper) GetValidator(ctx sdk.Context, eeAddress sdk.EEAddr
 	return validator, true
 }
 
-func (k ExecutionLayerKeeper) SetValidator(ctx sdk.Context, eeAddress sdk.EEAddress, validator types.Validator) {
+func (k ExecutionLayerKeeper) SetValidator(ctx sdk.Context, accAddress sdk.AccAddress, validator types.Validator) {
 	store := ctx.KVStore(k.HashMapStoreKey)
 	validatorBytes := types.MustMarshalValidator(k.cdc, validator)
-	store.Set(types.GetValidatorKey(eeAddress), validatorBytes)
+	store.Set(types.GetValidatorKey(accAddress), validatorBytes)
 }
 
-func (k ExecutionLayerKeeper) GetValidatorConsPubKey(ctx sdk.Context, eeAddress sdk.EEAddress) crypto.PubKey {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) GetValidatorConsPubKey(ctx sdk.Context, accAddress sdk.AccAddress) crypto.PubKey {
+	validator, _ := k.GetValidator(ctx, accAddress)
 
 	return validator.ConsPubKey
 }
 
-func (k ExecutionLayerKeeper) SetValidatorConsPubKey(ctx sdk.Context, eeAddress sdk.EEAddress, pubKey crypto.PubKey) {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) SetValidatorConsPubKey(ctx sdk.Context, accAddress sdk.AccAddress, pubKey crypto.PubKey) {
+	validator, _ := k.GetValidator(ctx, accAddress)
 	validator.ConsPubKey = pubKey
-	k.SetValidator(ctx, eeAddress, validator)
+	k.SetValidator(ctx, accAddress, validator)
 }
 
-func (k ExecutionLayerKeeper) GetValidatorDescription(ctx sdk.Context, eeAddress sdk.EEAddress) types.Description {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) GetValidatorDescription(ctx sdk.Context, accAddress sdk.AccAddress) types.Description {
+	validator, _ := k.GetValidator(ctx, accAddress)
 
 	return validator.Description
 }
 
-func (k ExecutionLayerKeeper) SetValidatorDescription(ctx sdk.Context, eeAddress sdk.EEAddress, description types.Description) {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) SetValidatorDescription(ctx sdk.Context, accAddress sdk.AccAddress, description types.Description) {
+	validator, _ := k.GetValidator(ctx, accAddress)
 	validator.Description = description
-	k.SetValidator(ctx, eeAddress, validator)
+	k.SetValidator(ctx, accAddress, validator)
 }
 
-func (k ExecutionLayerKeeper) GetValidatorStake(ctx sdk.Context, eeAddress sdk.EEAddress) string {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) GetValidatorStake(ctx sdk.Context, accAddress sdk.AccAddress) string {
+	validator, _ := k.GetValidator(ctx, accAddress)
 
 	return validator.Stake
 }
 
-func (k ExecutionLayerKeeper) SetValidatorStake(ctx sdk.Context, eeAddress sdk.EEAddress, stake string) {
-	validator, _ := k.GetValidator(ctx, eeAddress)
+func (k ExecutionLayerKeeper) SetValidatorStake(ctx sdk.Context, accAddress sdk.AccAddress, stake string) {
+	validator, _ := k.GetValidator(ctx, accAddress)
 	validator.Stake = stake
-	k.SetValidator(ctx, eeAddress, validator)
+	k.SetValidator(ctx, accAddress, validator)
 }
 
 func (k ExecutionLayerKeeper) GetAllValidators(ctx sdk.Context) (validators []types.Validator) {

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -245,7 +245,7 @@ func TestValidator(t *testing.T) {
 
 	valPubKeyStr := "fridayvaloperpub1addwnpepqfaxrvy4f95duln3t6vvtd0qd0sdpwfsn3fh9snpnq06w25qualj6vczad0"
 	valPubKey, _ := sdk.GetValPubKeyBech32(valPubKeyStr)
-	valAddr := sdk.AccAddress(valPubKey.Address()).ToEEAddress()
+	valAddr := sdk.AccAddress(valPubKey.Address())
 
 	consPubKey, _ := sdk.GetConsPubKeyBech32("fridayvalconspub16jrl8jvqq98x7jjxfcm8252pwd4nv6fetpzk6nzx2ddyc3fn0p2rz4mwf44nqjtfga5k5at4xad82sjhx9r9zdfcwuc5uvt90934jjr4d4xk242909rxks28v9erv3jvwfcx2wp4fe8h54fsddu9zar5v3tyknrs8pykk2mw2p29j4n6w455c7j2d3x4ykft9akx6s24gsu8ys2nvayrykqst965z")
 	val := types.NewValidator(valAddr, consPubKey, types.Description{

--- a/x/executionlayer/types/codec.go
+++ b/x/executionlayer/types/codec.go
@@ -15,6 +15,7 @@ func init() {
 // RegisterCodec registers concrete types on the Amino codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgCreateValidator{}, "executionengine/CreateValidator", nil)
+	cdc.RegisterConcrete(MsgEditValidator{}, "executionengine/EditValidator", nil)
 	cdc.RegisterConcrete(MsgExecute{}, "executionengine/Execute", nil)
 	cdc.RegisterConcrete(MsgTransfer{}, "executionengine/Transfer", nil)
 	cdc.RegisterConcrete(MsgBond{}, "executionengine/Bond", nil)

--- a/x/executionlayer/types/key.go
+++ b/x/executionlayer/types/key.go
@@ -27,6 +27,6 @@ func GetEEStateKey(eeState []byte) []byte {
 	return append(EEStateKey, eeState...)
 }
 
-func GetValidatorKey(operatorAddr sdk.EEAddress) []byte {
+func GetValidatorKey(operatorAddr sdk.AccAddress) []byte {
 	return append(ValidatorKey, operatorAddr.Bytes()...)
 }

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -228,6 +228,45 @@ func (msg MsgCreateValidator) ValidateBasic() sdk.Error {
 }
 
 //______________________________________________________________________
+// MsgEditValidator - struct for editing a validator
+type MsgEditValidator struct {
+	ValidatorAddress sdk.AccAddress `json:"address" yaml:"address"`
+	Description
+}
+
+func NewMsgEditValidator(valAddr sdk.AccAddress, description Description) MsgEditValidator {
+	return MsgEditValidator{
+		ValidatorAddress: valAddr,
+		Description:      description,
+	}
+}
+
+//nolint
+func (msg MsgEditValidator) Route() string { return RouterKey }
+func (msg MsgEditValidator) Type() string  { return "edit_validator" }
+func (msg MsgEditValidator) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.ValidatorAddress}
+}
+
+// get the bytes for the message signer to sign on
+func (msg MsgEditValidator) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// quick validity check
+func (msg MsgEditValidator) ValidateBasic() sdk.Error {
+	if msg.ValidatorAddress.Empty() {
+		return sdk.NewError(DefaultCodespace, CodeInvalidInput, "nil validator address")
+	}
+
+	if msg.Description == (Description{}) {
+		return sdk.NewError(DefaultCodespace, CodeInvalidInput, "transaction must include some information to modify")
+	}
+	return nil
+}
+
+//______________________________________________________________________
 type MsgBond struct {
 	ContractAddress string         `json:"contract_address" yaml:"contract_address"`
 	FromAddress     sdk.AccAddress `json:"from_address" yaml:"from_address"`

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -61,3 +61,15 @@ type QueryExecutionLayerResp struct {
 func (q QueryExecutionLayerResp) String() string {
 	return fmt.Sprintf("Value: %s", q.Value)
 }
+
+// defines the params for the following queries:
+// - 'custom/%s/validator'
+type QueryValidatorParams struct {
+	ValidatorAddr sdk.AccAddress
+}
+
+func NewQueryValidatorParams(validatorAddr sdk.AccAddress) QueryValidatorParams {
+	return QueryValidatorParams{
+		ValidatorAddr: validatorAddr,
+	}
+}

--- a/x/executionlayer/types/validator.go
+++ b/x/executionlayer/types/validator.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hdac-io/friday/codec"
 	sdk "github.com/hdac-io/friday/types"
@@ -180,4 +181,14 @@ func (v Validator) TestEquivalent(v2 Validator) bool {
 // return the TM validator address
 func (v Validator) ConsAddress() sdk.ConsAddress {
 	return sdk.ConsAddress(v.ConsPubKey.Address())
+}
+
+// Validators is a collection of Validator
+type Validators []Validator
+
+func (v Validators) String() (out string) {
+	for _, val := range v {
+		out += val.String() + "\n"
+	}
+	return strings.TrimSpace(out)
 }

--- a/x/executionlayer/types/validator.go
+++ b/x/executionlayer/types/validator.go
@@ -19,14 +19,14 @@ const (
 
 // Validator - save a validater information
 type Validator struct {
-	OperatorAddress sdk.EEAddress `json:"operator_address" yaml:"operator_address"` // address of the validator's operator; bech encoded in JSON
-	ConsPubKey      crypto.PubKey `json:"consensus_pubkey" yaml:"consensus_pubkey"` // the consensus public key of the validator; bech encoded in JSON
-	Description     Description   `json:"description" yaml:"description"`           // description terms for the validator
-	Stake           string        `json:"stake" yaml:"stake"`
+	OperatorAddress sdk.AccAddress `json:"operator_address" yaml:"operator_address"` // address of the validator's operator; bech encoded in JSON
+	ConsPubKey      crypto.PubKey  `json:"consensus_pubkey" yaml:"consensus_pubkey"` // the consensus public key of the validator; bech encoded in JSON
+	Description     Description    `json:"description" yaml:"description"`           // description terms for the validator
+	Stake           string         `json:"stake" yaml:"stake"`
 }
 
 // NewValidator - initialize a new validator
-func NewValidator(operator sdk.EEAddress, pubKey crypto.PubKey, description Description, stake string) Validator {
+func NewValidator(operator sdk.AccAddress, pubKey crypto.PubKey, description Description, stake string) Validator {
 	return Validator{
 		OperatorAddress: operator,
 		ConsPubKey:      pubKey,

--- a/x/executionlayer/types/validator_test.go
+++ b/x/executionlayer/types/validator_test.go
@@ -13,11 +13,10 @@ func TestValidatorTestEquivalent(t *testing.T) {
 	valAddr := sdk.ValAddress(acc)
 
 	require.Equal(t, "fridayvaloper19rxdgfn3grqgwc6zhyeljmyas3tsawn64dsges", valAddr.String())
-	eeAddress := acc.ToEEAddress()
 
 	consPubKey, _ := sdk.GetConsPubKeyBech32("fridayvalconspub16jrl8jvqq98x7jjxfcm8252pwd4nv6fetpzk6nzx2ddyc3fn0p2rz4mwf44nqjtfga5k5at4xad82sjhx9r9zdfcwuc5uvt90934jjr4d4xk242909rxks28v9erv3jvwfcx2wp4fe8h54fsddu9zar5v3tyknrs8pykk2mw2p29j4n6w455c7j2d3x4ykft9akx6s24gsu8ys2nvayrykqst965z")
-	val1 := NewValidator(eeAddress, consPubKey, Description{}, "0")
-	val2 := NewValidator(eeAddress, consPubKey, Description{}, "0")
+	val1 := NewValidator(acc, consPubKey, Description{}, "0")
+	val2 := NewValidator(acc, consPubKey, Description{}, "0")
 
 	ok := val1.TestEquivalent(val2)
 	require.True(t, ok)


### PR DESCRIPTION
Update
--
- add to edit validator
- add to query about validator
- add to rest about validator
- refactoring unuse valpubkey in validator

Review
--
- cli test
>- `clif hdac edit-validator --wallet alsa --moniker validator`
>- `clif hdac validator --wallet alsa`
>- `clif hdac validator`

- For rest test `clif rest-server`
>- Query All Validator : GET `http://localhost:1317/contract/validators`
>- Query Validdator : GET `http://localhost:1317/contract/validators?address=friday135260rslw2gkhpph2gjclm5zvvaeaf9qw7tknm`
>- Create Validator : PUT `http://localhost:1317/contract/validators`
>- Edit Validator : POST `http://localhost:1317/contract/validators`