### PR TITLE
Added cargo PATH into environment

### DIFF
--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -16,6 +16,7 @@ cd CasperLabs
 git fetch origin refs/tags/$CASPERLABS_TARGET_TAG:refs/tags/$CASPERLABS_TARGET_TAG
 git checkout $CASPERLABS_TARGET_TAG
 
+source $HOME/.cargo/env
 cd execution-engine
 make setup
 cargo build --release # build execution engine


### PR DESCRIPTION
## Update
* Added `source $HOME/.cargo/env` into `make` script
(Error in Casperlabs EE build in vanila Ubuntu)

## Review
* Omit cargo PATH and run `make install`