### PR TITLE
feat: support to json args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.0
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciD
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
 github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.0 h1:iB7RSXcrhiFI2xvCWRz1UigarIWXwbeXxY8JpUafyKk=
 github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a h1:5rHMQUi1zgjKYlgIQahGrirzaJgR2UpgQzc3BjxdkIs=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=
@@ -280,6 +282,7 @@ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a h1:YX8ljsm6wXlHZO+aRz9Exqr0evNhKRNe5K/gi+zKh4U=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/go.sum
+++ b/go.sum
@@ -113,10 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.0 h1:iB7RSXcrhiFI2xvCWRz1UigarIWXwbeXxY8JpUafyKk=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a h1:5rHMQUi1zgjKYlgIQahGrirzaJgR2UpgQzc3BjxdkIs=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.1.1-0.20200213022357-44a923f9f06a/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0 h1:J8fsIADiXvFg62YC9COkkD66u+CtZQeBIbPPbfTFu9I=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=
@@ -282,7 +280,6 @@ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a h1:YX8ljsm6wXlHZO+aRz9Exqr0evNhKRNe5K/gi+zKh4U=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -97,7 +97,10 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				sessionAbi = util.AbiDeployArgsTobytes(sessionArgs)
+				sessionAbi, err = util.AbiDeployArgsTobytes(sessionArgs)
+				if err != nil {
+					return err
+				}
 			}
 
 			fee, err := strconv.ParseUint(args[3], 10, 64)

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -57,13 +57,18 @@ func handlerMsgTransfer(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgTr
 					LongValue: int64(msg.Amount)}}},
 	}
 
+	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	if err != nil {
+		return getResult(false, err.Error())
+	}
+
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
 		// TODO Will be change store contract call
 		util.WASM,
 		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/transfer_to_account.wasm")),
-		util.AbiDeployArgsTobytes(sessionArgs),
+		sessionAbi,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -123,13 +128,18 @@ func handlerMsgBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgBond) 
 					LongValue: int64(msg.Amount)}}},
 	}
 
+	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	if err != nil {
+		return getResult(false, err.Error())
+	}
+
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
 		// TODO Will be change store contract call
 		util.WASM,
 		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/bonding.wasm")),
-		util.AbiDeployArgsTobytes(sessionArgs),
+		sessionAbi,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -146,13 +156,18 @@ func handlerMsgUnBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnBo
 						Value: &consensus.Deploy_Arg_Value_LongValue{
 							LongValue: int64(msg.Amount)}}}}}}
 
+	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	if err != nil {
+		return getResult(false, err.Error())
+	}
+
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
 		// TODO Will be change store contract call
 		util.WASM,
 		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/unbonding.wasm")),
-		util.AbiDeployArgsTobytes(sessionArgs),
+		sessionAbi,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -176,12 +191,16 @@ func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute) (boo
 						Value:    strconv.FormatUint(msg.Fee, 10),
 						BitWidth: 512}}}}}
 
+	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
+	if err != nil {
+		return false, err.Error()
+	}
 	// Execute
 	deploys := []*ipc.DeployItem{}
 	deploy := util.MakeDeploy(
 		ProtobufSafeEncodeBytes(msg.ExecAddress.ToEEAddress()),
 		msg.SessionType, ProtobufSafeEncodeBytes(msg.SessionCode), ProtobufSafeEncodeBytes(msg.SessionArgs),
-		util.WASM, util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/standard_payment.wasm")), util.AbiDeployArgsTobytes(paymentArgs),
+		util.WASM, util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/standard_payment.wasm")), paymentAbi,
 		msg.GasPrice, ctx.BlockTime().Unix(), ctx.ChainID())
 	deploys = append(deploys, deploy)
 	reqExecute := &ipc.ExecuteRequest{

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -3,7 +3,6 @@ package executionlayer
 import (
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"path"
 	"reflect"
 	"strconv"
@@ -103,9 +102,7 @@ func TestCreateBlock(t *testing.T) {
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterDefineWasm)),
 		[]byte{},
-		util.WASM,
-		util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm)),
-		util.MakeArgsStandardPayment(new(big.Int).SetUint64(200000000)),
+		uint64(100000000),
 		uint64(10),
 	)
 	handlerMsgExecute(input.ctx, input.elk, counterDefineMSG)
@@ -125,9 +122,7 @@ func TestCreateBlock(t *testing.T) {
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterCallWasm)),
 		[]byte{},
-		util.WASM,
-		util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm)),
-		util.MakeArgsStandardPayment(new(big.Int).SetUint64(200000000)),
+		uint64(100000000),
 		uint64(10),
 	)
 	handlerMsgExecute(input.ctx, input.elk, counterCallMSG)

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -2,12 +2,13 @@ package executionlayer
 
 import (
 	"fmt"
-	"math/big"
 	"os"
 	"path"
 	"time"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/codec"
 	"github.com/hdac-io/friday/store"
@@ -122,7 +123,16 @@ func genesis(input testInput) []byte {
 func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	input := setupTestInput()
 	timestamp := time.Now().Unix()
-	paymentAbi := util.MakeArgsStandardPayment(new(big.Int).SetUint64(200000000))
+	paymentArgs := []*consensus.Deploy_Arg{
+		&consensus.Deploy_Arg{
+			Name: "fee",
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_BigInt{
+					BigInt: &state.BigInt{
+						Value:    "100000000",
+						BitWidth: 512,
+					}}}}}
+	paymentAbi := util.AbiDeployArgsTobytes(paymentArgs)
 	cntDefCode := util.LoadWasmFile(path.Join(contractPath, counterDefineWasm))
 	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
@@ -151,7 +161,16 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	input := setupTestInput()
 	timestamp := time.Now().Unix()
-	paymentAbi := util.MakeArgsStandardPayment(new(big.Int).SetUint64(200000000))
+	paymentArgs := []*consensus.Deploy_Arg{
+		&consensus.Deploy_Arg{
+			Name: "fee",
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_BigInt{
+					BigInt: &state.BigInt{
+						Value:    "100000000",
+						BitWidth: 512,
+					}}}}}
+	paymentAbi := util.AbiDeployArgsTobytes(paymentArgs)
 	cntCallCode := util.LoadWasmFile(path.Join(contractPath, counterCallWasm))
 	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -132,7 +132,10 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 						Value:    "100000000",
 						BitWidth: 512,
 					}}}}}
-	paymentAbi := util.AbiDeployArgsTobytes(paymentArgs)
+	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
+	if err != nil {
+		panic(fmt.Sprintf("fail to convert payment abi: %s", err.Error()))
+	}
 	cntDefCode := util.LoadWasmFile(path.Join(contractPath, counterDefineWasm))
 	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
@@ -170,7 +173,10 @@ func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 						Value:    "100000000",
 						BitWidth: 512,
 					}}}}}
-	paymentAbi := util.AbiDeployArgsTobytes(paymentArgs)
+	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
+	if err != nil {
+		panic(fmt.Sprintf("fail to convert payment abi: %s", err.Error()))
+	}
 	cntCallCode := util.LoadWasmFile(path.Join(contractPath, counterCallWasm))
 	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -18,9 +18,7 @@ type MsgExecute struct {
 	SessionType     util.ContractType `json:"session_type"`
 	SessionCode     []byte            `json:"session_code"`
 	SessionArgs     []byte            `json:"session_args"`
-	PaymentType     util.ContractType `json:"payment_type"`
-	PaymentCode     []byte            `json:"payment_code"`
-	PaymentArgs     []byte            `json:"payment_args"`
+	Fee             uint64            `json:"fee"`
 	GasPrice        uint64            `json:"gas_price"`
 }
 
@@ -30,9 +28,7 @@ func NewMsgExecute(
 	execAddress sdk.AccAddress,
 	sessionType util.ContractType,
 	sessionCode, sessionArgs []byte,
-	paymentType util.ContractType,
-	paymentCode, paymentArgs []byte,
-	gasPrice uint64,
+	fee, gasPrice uint64,
 ) MsgExecute {
 	return MsgExecute{
 		ExecAddress:     execAddress,
@@ -40,9 +36,7 @@ func NewMsgExecute(
 		SessionType:     sessionType,
 		SessionCode:     sessionCode,
 		SessionArgs:     sessionArgs,
-		PaymentType:     paymentType,
-		PaymentCode:     paymentCode,
-		PaymentArgs:     paymentArgs,
+		Fee:             fee,
 		GasPrice:        gasPrice,
 	}
 }


### PR DESCRIPTION
- using args instead of direct abi
- support to json args in custom contract
>````[{"name":"amount","value":{"int_value":123456}},{"name":"fee","value":{"int_value":54321}}]````
>- ~~Becaful json variable name, google protobuf using camelCase..~~ support all

~~P.S. If merged https://github.com/hdac-io/casperlabs-ee-grpc-go-util/pull/9, I'll change go.mod.~~ v0.2.0