### PR TITLE
Rollbacked to nested JSON form with "base_req" keyword

### DIFF
--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -16,7 +16,6 @@ import (
 type transferReq struct {
 	BaseReq                    rest.BaseReq `json:"base_req"`
 	TokenContractAddress       string       `json:"token_contract_address"`
-	SenderAddressOrNickname    string       `json:"sender_address_or_nickname"`
 	RecipientAddressOrNickname string       `json:"recipient_address_or_nickname"`
 	Amount                     uint64       `json:"amount"`
 	Fee                        uint64       `json:"fee"`
@@ -31,11 +30,11 @@ func transferMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 	}
 
 	var senderAddr sdk.AccAddress
-	senderAddr, err := sdk.AccAddressFromBech32(req.SenderAddressOrNickname)
+	senderAddr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 	if err != nil {
-		senderAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.SenderAddressOrNickname)
+		senderAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.BaseReq.From)
 		if err != nil {
-			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.SenderAddressOrNickname)
+			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.BaseReq.From)
 		}
 	}
 
@@ -72,7 +71,6 @@ func transferMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 type bondReq struct {
 	BaseReq              rest.BaseReq `json:"base_req"`
 	TokenContractAddress string       `json:"token_contract_address"`
-	AddressOrNickname    string       `json:"address_or_nickname"`
 	Amount               uint64       `json:"amount"`
 	Fee                  uint64       `json:"fee"`
 }
@@ -87,11 +85,11 @@ func bondUnbondMsgCreator(bondIsTrue bool, w http.ResponseWriter, cliCtx context
 
 	// Parameter touching
 	var addr sdk.AccAddress
-	addr, err := sdk.AccAddressFromBech32(req.AddressOrNickname)
+	addr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 	if err != nil {
-		addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.AddressOrNickname)
+		addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.BaseReq.From)
 		if err != nil {
-			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse address or name: %s", req.AddressOrNickname)
+			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse address or name: %s", req.BaseReq.From)
 		}
 	}
 
@@ -155,10 +153,9 @@ func getBalanceQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 }
 
 type createValidatorReq struct {
-	BaseReq                    rest.BaseReq      `json:"base_req"`
-	ValidatorAddressOrNickName string            `json:"validator_address_or_nickname"`
-	ConsPubKey                 string            `json:"cons_pub_key"`
-	Description                types.Description `json:"description"`
+	BaseReq     rest.BaseReq      `json:"base_req"`
+	ConsPubKey  string            `json:"cons_pub_key"`
+	Description types.Description `json:"description"`
 }
 
 func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) (rest.BaseReq, []sdk.Msg, error) {
@@ -170,11 +167,11 @@ func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext,
 	}
 
 	var valAddr sdk.AccAddress
-	valAddr, err := sdk.AccAddressFromBech32(req.ValidatorAddressOrNickName)
+	valAddr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 	if err != nil {
-		valAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.ValidatorAddressOrNickName)
+		valAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.BaseReq.From)
 		if err != nil {
-			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.ValidatorAddressOrNickName)
+			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.BaseReq.From)
 		}
 	}
 
@@ -200,9 +197,8 @@ func createValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext,
 }
 
 type editValidatorReq struct {
-	BaseReq                    rest.BaseReq      `json:"base_req"`
-	ValidatorAddressOrNickName string            `json:"validator_address_or_nickname"`
-	Description                types.Description `json:"description"`
+	BaseReq     rest.BaseReq      `json:"base_req"`
+	Description types.Description `json:"description"`
 }
 
 func editValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) (rest.BaseReq, []sdk.Msg, error) {
@@ -214,11 +210,11 @@ func editValidatorMsgCreator(w http.ResponseWriter, cliCtx context.CLIContext, r
 	}
 
 	var valAddr sdk.AccAddress
-	valAddr, err := sdk.AccAddressFromBech32(req.ValidatorAddressOrNickName)
+	valAddr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 	if err != nil {
-		valAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.ValidatorAddressOrNickName)
+		valAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, req.BaseReq.From)
 		if err != nil {
-			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.ValidatorAddressOrNickName)
+			return rest.BaseReq{}, nil, fmt.Errorf("failed to parse sender address or name: %s", req.BaseReq.From)
 		}
 	}
 

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -41,7 +41,6 @@ func TestRESTTransfer(t *testing.T) {
 	transReq := transferReq{
 		BaseReq:                    basereq,
 		TokenContractAddress:       fromAddr,
-		SenderAddressOrNickname:    fromAddr,
 		RecipientAddressOrNickname: receipAddr,
 		Amount:                     20_000_000,
 		Fee:                        10_000_000,
@@ -59,14 +58,13 @@ func TestRESTTransfer(t *testing.T) {
 }
 
 func TestRESTBond(t *testing.T) {
-	fromAddr, _, writer, clictx, basereq := prepare()
+	_, _, writer, clictx, basereq := prepare()
 
 	// Body
 	bondReq := bondReq{
-		BaseReq:           basereq,
-		AddressOrNickname: fromAddr,
-		Amount:            100_000_000,
-		Fee:               10_000_000,
+		BaseReq: basereq,
+		Amount:  100_000_000,
+		Fee:     10_000_000,
 	}
 
 	// http.request
@@ -81,14 +79,13 @@ func TestRESTBond(t *testing.T) {
 }
 
 func TestRESTUnbond(t *testing.T) {
-	fromAddr, _, writer, clictx, basereq := prepare()
+	_, _, writer, clictx, basereq := prepare()
 
 	// Body
 	bondReq := bondReq{
-		BaseReq:           basereq,
-		AddressOrNickname: fromAddr,
-		Amount:            100_000_000,
-		Fee:               10_000_000,
+		BaseReq: basereq,
+		Amount:  100_000_000,
+		Fee:     10_000_000,
 	}
 
 	// http.request
@@ -133,13 +130,12 @@ func TestRESTGetValidators(t *testing.T) {
 }
 
 func TestRESTCreateValidator(t *testing.T) {
-	fromAddr, _, writer, clictx, basereq := prepare()
+	_, _, writer, clictx, basereq := prepare()
 
 	createValidatorReq := createValidatorReq{
-		BaseReq:                    basereq,
-		ValidatorAddressOrNickName: fromAddr,
-		ConsPubKey:                 "fridayvalconspub16jrl8jvqq9k957nfd43n2dnyxc6nsazpgf5yuwtzfe6kku63ga6nvtmcdeg92vj4gy4kkd62vd69vvnhx935w5zpw9ex7733tft8we6evemzke66xv4ks56gfdvx66ndfye5x5z9fs6j74z6g3u4zdzd0p8hw6mr24k8wjzx0ghhz5z8vdm92vjs2e8xwdn5xpvxu56fvejnj7t6wsens5gwxlen9",
-		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
+		BaseReq:     basereq,
+		ConsPubKey:  "fridayvalconspub16jrl8jvqq9k957nfd43n2dnyxc6nsazpgf5yuwtzfe6kku63ga6nvtmcdeg92vj4gy4kkd62vd69vvnhx935w5zpw9ex7733tft8we6evemzke66xv4ks56gfdvx66ndfye5x5z9fs6j74z6g3u4zdzd0p8hw6mr24k8wjzx0ghhz5z8vdm92vjs2e8xwdn5xpvxu56fvejnj7t6wsens5gwxlen9",
+		Description: types.NewDescription("moniker", "identity", "https://test.io", "details"),
 	}
 
 	body := clictx.Codec.MustMarshalJSON(createValidatorReq)
@@ -153,12 +149,11 @@ func TestRESTCreateValidator(t *testing.T) {
 }
 
 func TestRESTEditValidator(t *testing.T) {
-	fromAddr, _, writer, clictx, basereq := prepare()
+	_, _, writer, clictx, basereq := prepare()
 
 	editValidatorReq := editValidatorReq{
-		BaseReq:                    basereq,
-		ValidatorAddressOrNickName: fromAddr,
-		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
+		BaseReq:     basereq,
+		Description: types.NewDescription("moniker", "identity", "https://test.io", "details"),
 	}
 
 	body := clictx.Codec.MustMarshalJSON(editValidatorReq)

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/hdac-io/friday/client/context"
@@ -39,15 +38,12 @@ func TestRESTTransfer(t *testing.T) {
 	fromAddr, receipAddr, writer, clictx, basereq := prepare()
 
 	// Body
-	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	transReq := transferReq{
-		ChainID:                    basereq.ChainID,
-		Memo:                       basereq.Memo,
+		BaseReq:                    basereq,
 		TokenContractAddress:       fromAddr,
 		SenderAddressOrNickname:    fromAddr,
 		RecipientAddressOrNickname: receipAddr,
 		Amount:                     20_000_000,
-		GasPrice:                   gas,
 		Fee:                        10_000_000,
 	}
 
@@ -66,14 +62,11 @@ func TestRESTBond(t *testing.T) {
 	fromAddr, _, writer, clictx, basereq := prepare()
 
 	// Body
-	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	bondReq := bondReq{
-		ChainID:           basereq.ChainID,
-		Memo:              basereq.Memo,
+		BaseReq:           basereq,
 		AddressOrNickname: fromAddr,
 		Amount:            100_000_000,
 		Fee:               10_000_000,
-		GasPrice:          gas,
 	}
 
 	// http.request
@@ -91,14 +84,11 @@ func TestRESTUnbond(t *testing.T) {
 	fromAddr, _, writer, clictx, basereq := prepare()
 
 	// Body
-	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	bondReq := bondReq{
-		ChainID:           basereq.ChainID,
-		Memo:              basereq.Memo,
+		BaseReq:           basereq,
 		AddressOrNickname: fromAddr,
 		Amount:            100_000_000,
 		Fee:               10_000_000,
-		GasPrice:          gas,
 	}
 
 	// http.request
@@ -145,14 +135,11 @@ func TestRESTGetValidators(t *testing.T) {
 func TestRESTCreateValidator(t *testing.T) {
 	fromAddr, _, writer, clictx, basereq := prepare()
 
-	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	createValidatorReq := createValidatorReq{
-		ChainID:                    basereq.ChainID,
+		BaseReq:                    basereq,
 		ValidatorAddressOrNickName: fromAddr,
 		ConsPubKey:                 "fridayvalconspub16jrl8jvqq9k957nfd43n2dnyxc6nsazpgf5yuwtzfe6kku63ga6nvtmcdeg92vj4gy4kkd62vd69vvnhx935w5zpw9ex7733tft8we6evemzke66xv4ks56gfdvx66ndfye5x5z9fs6j74z6g3u4zdzd0p8hw6mr24k8wjzx0ghhz5z8vdm92vjs2e8xwdn5xpvxu56fvejnj7t6wsens5gwxlen9",
 		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
-		Gas:                        gas,
-		Memo:                       basereq.Memo,
 	}
 
 	body := clictx.Codec.MustMarshalJSON(createValidatorReq)
@@ -168,13 +155,10 @@ func TestRESTCreateValidator(t *testing.T) {
 func TestRESTEditValidator(t *testing.T) {
 	fromAddr, _, writer, clictx, basereq := prepare()
 
-	gas, _ := strconv.ParseUint(basereq.Gas, 10, 64)
 	editValidatorReq := editValidatorReq{
-		ChainID:                    basereq.ChainID,
+		BaseReq:                    basereq,
 		ValidatorAddressOrNickName: fromAddr,
 		Description:                types.NewDescription("moniker", "identity", "https://test.io", "details"),
-		Gas:                        gas,
-		Memo:                       basereq.Memo,
 	}
 
 	body := clictx.Codec.MustMarshalJSON(editValidatorReq)

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -14,13 +14,18 @@ import (
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) {
-	r.HandleFunc(fmt.Sprintf("/%s/transfer", storeName), transferHandler(cliCtx)).Methods("POST")
-	r.HandleFunc(fmt.Sprintf("/%s/bond", storeName), bondHandler(cliCtx)).Methods("POST")
-	r.HandleFunc(fmt.Sprintf("/%s/unbond", storeName), unbondHandler(cliCtx)).Methods("POST")
-	r.HandleFunc(fmt.Sprintf("/%s/balance", storeName), getBalanceHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), getValidatorHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), createValidatorHandler(cliCtx)).Methods("POST")
-	r.HandleFunc(fmt.Sprintf("/%s/validators", storeName), editValidatorHandler(cliCtx)).Methods("PUT")
+	const (
+		hdacSpecific = "hdac"
+		general      = "contract"
+	)
+
+	r.HandleFunc(fmt.Sprintf("/%s/transfer", hdacSpecific), transferHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/bond", hdacSpecific), bondHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/unbond", hdacSpecific), unbondHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/balance", hdacSpecific), getBalanceHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), getValidatorHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), createValidatorHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), editValidatorHandler(cliCtx)).Methods("PUT")
 }
 
 func transferHandler(cliCtx context.CLIContext) http.HandlerFunc {

--- a/x/executionlayer/client/util/util.go
+++ b/x/executionlayer/client/util/util.go
@@ -15,7 +15,8 @@ import (
 // GetAddress searches address in nickname mapping
 func GetAddress(cdc *codec.Codec, cliCtx context.CLIContext, addressOrName string) (sdk.AccAddress, error) {
 	var address sdk.AccAddress
-	address, err := sdk.AccAddressFromBech32(addressOrName)
+	var err error
+	address, err = sdk.AccAddressFromBech32(addressOrName)
 	if err != nil {
 		queryData := idtype.QueryReqUnitAccount{
 			Nickname: addressOrName,

--- a/x/nickname/client/rest/rest.go
+++ b/x/nickname/client/rest/rest.go
@@ -29,10 +29,8 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 // Tx Handler
 
 type newNickname struct {
-	BaseReq rest.BaseReq `json:"base_req"`
-
-	Nickname string `json:"nickname"`
-	Address  string `json:"address"`
+	BaseReq  rest.BaseReq `json:"base_req"`
+	Nickname string       `json:"nickname"`
 }
 
 func newNicknameHandler(cliCtx context.CLIContext) http.HandlerFunc {
@@ -43,12 +41,11 @@ func newNicknameHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		addr, err := sdk.AccAddressFromBech32(req.Address)
+		addr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse from given address")
 		}
 
-		req.BaseReq.From = req.Address
 		if !req.BaseReq.ValidateBasic(w) {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse base request")
 			return
@@ -73,11 +70,9 @@ func newNicknameHandler(cliCtx context.CLIContext) http.HandlerFunc {
 }
 
 type changeKey struct {
-	BaseReq rest.BaseReq `json:"base_req"`
-
-	Nickname   string `json:"nickname"`
-	OldAddress string `json:"old_address"`
-	NewAddress string `json:"new_address"`
+	BaseReq    rest.BaseReq `json:"base_req"`
+	Nickname   string       `json:"nickname"`
+	NewAddress string       `json:"new_address"`
 }
 
 func changeKeyHandler(cliCtx context.CLIContext) http.HandlerFunc {
@@ -88,7 +83,7 @@ func changeKeyHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		oldaddr, err := sdk.AccAddressFromBech32(req.OldAddress)
+		oldaddr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse 'old_address'")
 		}
@@ -98,7 +93,6 @@ func changeKeyHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse 'new_address'")
 		}
 
-		req.BaseReq.From = req.OldAddress
 		req.BaseReq = req.BaseReq.Sanitize()
 		if !req.BaseReq.ValidateBasic(w) {
 			return


### PR DESCRIPTION
## Update
* `base_req` JSON key category rebirthed

## Good to review
1. Install [Postman](https://www.postman.com/)
1. Launch `nodef start` & `clif rest-server`
1. Test the endpoints below

### `POST /hdac/transfer`
```json
{
	"base_req": {
		"chain_id": "testnet",
		"gas": "20000000",
		"memo": "",
		"from": "princesselsa"
	},
	"recipient_address_or_nickname":"friday1y2dx0evs5k6hxuhfrfdmm7wcwsrqr073htghpv",
	"amount":"1000000",
	"fee": "100000000"
}
```

### `POST /hdac/bond     /    /hdac/unbond`
```json
{
	"base_req": {
		"chain_id": "testnet",
		"gas": "20000000",
		"memo": "",
		"from": "princesselsa"
	},
	"fee": "100000000",
	"amount":"1000000"
}
```

### `POST PUT /hdac/validators`
```json
{
	"base_req": {
		"chain_id": "testnet",
		"gas": "20000000",
		"memo": "",
		"from": "princesselsa"
	},
 "cons_pub_key":"fridayvalconspub16jrl8jvqq9cj7569gec8sd6dv4e4w46g25uk7vm52fpk6nfn23p5zv60xekxuse3df39sjz4g9d92nfc0f3rs3ec2fpxxum9wej52428w968xwzww9erw53ng5u9zu23fdvk226z0fnx5mn2f4qk542ygf9xjvptve6y7a6fxe8kjm6s2e3kja2twezyvmt5245ystm4ga94y4zjwfg523c477wna",
	"description":{
		"website": "https://hdac.io",
		"moniker": "testnode1"
	}
}
```