### PR TITLE
Unified the getter flag of the signer's private key to "from"

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -270,8 +270,21 @@ func (ctx CLIContext) PrintOutput(toPrint fmt.Stringer) (err error) {
 // an address or key name. If genOnly is true, only a valid Bech32
 // address is returned.
 func GetFromFields(from string, genOnly bool) (sdk.AccAddress, string, error) {
+	keybase, err := keys.NewKeyBaseFromHomeFlag()
+	if err != nil {
+		return nil, "", err
+	}
+
 	if from == "" {
-		return nil, "", nil
+		infoList, _ := keybase.List()
+
+		if len(infoList) > 1 {
+			return nil, "", fmt.Errorf("multiple wallets in local. Cannot specify one wallet")
+		} else if len(infoList) == 0 {
+			return nil, "", fmt.Errorf("no wallet in local")
+		}
+
+		return infoList[0].GetAddress(), infoList[0].GetName(), nil
 	}
 
 	if genOnly {
@@ -281,11 +294,6 @@ func GetFromFields(from string, genOnly bool) (sdk.AccAddress, string, error) {
 		}
 
 		return addr, "", nil
-	}
-
-	keybase, err := keys.NewKeyBaseFromHomeFlag()
-	if err != nil {
-		return nil, "", err
 	}
 
 	var info cryptokeys.Info

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -63,8 +63,10 @@ func NewCLIContextWithFrom(from string) CLIContext {
 	genOnly := viper.GetBool(flags.FlagGenerateOnly)
 	fromAddress, fromName, err := GetFromFields(from, genOnly)
 	if err != nil {
-		fmt.Printf("failed to get from fields: %v", err)
-		os.Exit(1)
+		// fmt.Printf("failed to get from fields: %v", err)
+		// os.Exit(1)
+		fromAddress = nil
+		fromName = ""
 	}
 
 	if !genOnly {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0 h1:J8fsIADiXvFg62YC9COkkD66u+CtZQeBIbPPbfTFu9I=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0 h1:IJKTCuAZq/wHXgGTl6kX6PUcbGtjpdDKMGyvoI7ACTQ=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,71 @@
+# Testing package
+
+## Package structure
+
+```plain
+integration_test
+  |- jenkins_jobs: Bash backup of Jenkins jobs
+  |- lib
+    |- cmd.py                           : CLI wrapper
+    |- error.py                         : Error suite
+  |- test_single_node_simple_cli.py     : Single node CLI kind-of CLI unit test. Runs in Travis CI
+
+  |- config_setting.py                  : Used in multinode test. Making `config.toml`
+  |- multinode_test_setup.py            : Create wallet, set genesis account, and signing genesis tx
+  |- test_multi_node_simple_cli.py      : Multi node CLI test for checking broadcasting. Runs in Jenkins
+```
+
+## Prerequisite
+
+* Python >= 3.6
+* `cd integration_test && pip3 install -r ./requirements.txt`
+
+## How to run
+
+* Single node test
+`pytest -s test_single_node_simple_cli.py`
+* Multi node test
+  * Ask @psy2848048 to make ID of [Jenkins](http://132.145.81.228:8080/)
+  * Go to `00_CI multinode test`
+  * Put your branch
+
+## When & How to put your test case
+
+* New CLI command is created
+* After bug fix, the fix & its reproduce test should be included
+* Input command wrapper in `lib/cmd.py`
+* Write related test case to `test_single_node_simple_cli.py` & `test_multi_node_simple_cli.py`
+* The name of the test method should be started from `test`. `pytest` framework gather tests by the name of the methods
+
+## Current test case
+
+1. Single node
+    * `00_get_balance`: Get balance by wallet alias
+    * `01_transfer_to`
+        1. Transfer another account
+        1. Check balance both of them
+    * `test02_1_simple_bond_unbond`:
+        1. Bond token and check whether the tx is valid or not
+        1. Unbond token and check whether the tx is valid or not
+    * `test03_simple_register_nickname`
+        1. Register nickname
+        1. Get address of the nickname and compare to local wallet query
+    * `test04_transfer_to_by_nickname`
+        1. Set nickname
+        1. Transfer by nickname recipient
+        1. Check balance by nickname
+1. Multi node
+    * `setup_class`: `create_validator` & `bond` some token
+    * `00_get_balance`: Get balance by wallet alias
+    * `01_transfer_to`
+        1. Pick random node, and send token to exist account
+        1. Pick random node, and check balance by wallet alias
+    * `test01_01_transfer_to_nonexistent_account`
+        1. Pick random node, and send token to non-exist account
+        1. Pick random node, and check balance by wallet alias (Checking account broadcast)
+    * `test03_simple_register_nickname`
+        1. Pick random node, and register nickname
+        1. Pick random node, and get address of the nickname and compare to local wallet query
+    * `test04_transfer_to_by_nickname`
+        1. Pick random node, and transfer token from one account by wallet alias, to another account by nickname
+        1. Pick random node, and transfer token from one account by nickname, to another account by address

--- a/integration_tests/lib/cmd.py
+++ b/integration_tests/lib/cmd.py
@@ -262,20 +262,12 @@ def get_bls_pubkey_remote(remote_address):
 ## Nickname CLI
 #################
 
-def set_nickname_by_address(passphrase: str, nickname: str, address: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname set {} --address {} --node {}", passphrase, nickname, address, node)
+def set_nickname(passphrase: str, nickname: str, address: str, node: str = "tcp://localhost:26657"):
+    return _tx_executor("clif nickname set {} --from {} --node {}", passphrase, nickname, address, node)
 
 
-def set_nickname_by_wallet_alias(passphrase: str, nickname: str, wallet_alias: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname set {} --wallet {} --node {}", passphrase, nickname, wallet_alias, node)
-
-
-def change_to_by_address(passphrase: str, nickname: str, new_address: str, old_address: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname change-to {} {} --address {} --node {}", passphrase, nickname, new_address, old_address, node)
-    
-
-def change_to_by_wallet(passphrase: str, nickname: str, new_address: str, wallet_alias: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname change-to {} {} --wallet {} --node {}", passphrase, nickname, new_address, wallet_alias, node)
+def change_address_of_nickname(passphrase: str, nickname: str, new_address: str, old_address: str, node: str = "tcp://localhost:26657"):
+    return _tx_executor("clif nickname change-to {} {} --from {} --node {}", passphrase, nickname, new_address, old_address, node)
 
 
 def get_address(nickname: str, node: str = "tcp://localhost:26657"):
@@ -287,23 +279,23 @@ def get_address(nickname: str, node: str = "tcp://localhost:26657"):
 ## Hdac custom CLI
 ##################
 
-def transfer_to(passphrase: str, recipient: str, amount: int, fee: int, gas_price: int, from_type: str, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac transfer-to {} {} {} {} --{} {} --node {}", passphrase, recipient, amount, fee, gas_price, from_type, from_value, node)
+def transfer_to(passphrase: str, recipient: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
+    return _tx_executor("clif hdac transfer-to {} {} {} {} --from {} --node {}", passphrase, recipient, amount, fee, gas_price, from_value, node)
 
 
-def bond(passphrase: str, amount: int, fee: int, gas_price: int, from_type: str, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac bond {} {} {} --{} {} --node {}", passphrase, amount, fee, gas_price, from_type, from_value, node)
+def bond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
+    return _tx_executor("clif hdac bond {} {} {} --from {} --node {}", passphrase, amount, fee, gas_price, from_value, node)
 
 
-def unbond(passphrase: str, amount: int, fee: int, gas_price: int, from_type: str, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac unbond {} {} {} --{} {} --node {}", passphrase, amount, fee, gas_price, from_type, from_value, node)
+def unbond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
+    return _tx_executor("clif hdac unbond {} {} {} --from {} --node {}", passphrase, amount, fee, gas_price, from_value, node)
 
 
-def get_balance(from_type: str, from_value: str, node: str = "tcp://localhost:26657"):
-    res = _process_executor("clif hdac getbalance --{} {} --node {}", from_type, from_value, node, need_output=True)
+def get_balance(from_value: str, node: str = "tcp://localhost:26657"):
+    res = _process_executor("clif hdac getbalance --from {} --node {}", from_value, node, need_output=True)
     return res
 
 
 def create_validator(passphrase: str, from_value: str, pubkey: str, moniker: str, identity: str='""', website: str='""', details: str='""', node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac create-validator --wallet {} --pubkey {} --moniker {} --identity {} --website {} --details {} --node {}",
+    return _tx_executor("clif hdac create-validator --from {} --pubkey {} --moniker {} --identity {} --website {} --details {} --node {}",
                       passphrase, from_value, pubkey, moniker, identity, website, details, node)

--- a/integration_tests/lib/cmd.py
+++ b/integration_tests/lib/cmd.py
@@ -17,7 +17,12 @@ def _process_executor(cmd: str, *args, need_output=False):
     outs = child.read().decode('utf-8')
 
     if need_output == True:
-        res = json.loads(outs)
+        try:
+            res = json.loads(outs)
+        except Exception as e:
+            print(e)
+            raise e
+
         return res
 
 
@@ -30,7 +35,11 @@ def _tx_executor(cmd: str, passphrase, *args):
         _ = child.sendline(passphrase)
         
         outs = child.read().decode('utf-8')
-        tx_hash = re.search(r'"txhash": "([A-Z0-9]+)"', outs).group(1)
+        try:
+            tx_hash = re.search(r'"txhash": "([A-Z0-9]+)"', outs).group(1)
+        except Exception as e:
+            print(outs)
+            raise e
 
     except pexpect.TIMEOUT:
         raise FinishedWithError
@@ -86,12 +95,13 @@ def copy_manifest():
     _ = _process_executor(cmd, need_output=False)
 
 
-def create_wallet(wallet_alias: str, passphrase: str):
+def create_wallet(wallet_alias: str, passphrase: str, client_home: str = '.test_clif'):
     """
     clif key add <wallet_alias>
     """
+    client_home = os.path.join(os.environ["HOME"], client_home)
     try:
-        child = pexpect.spawn("clif keys add {}".format(wallet_alias))
+        child = pexpect.spawn("clif keys add {} --home {}".format(wallet_alias, client_home))
         _ = child.read_nonblocking(10000, timeout=1)
         _ = child.sendline(passphrase)
         _ = child.read_nonblocking(10000, timeout=1)
@@ -114,14 +124,18 @@ def create_wallet(wallet_alias: str, passphrase: str):
         mnemonic = res['mnemonic']
 
     except json.JSONDecodeError:
-        # If output is not json
-        address = re.search(r"address: ([a-z0-9]+)", outs).group(1)
-        pubkey = re.search(r"pubkey: ([a-z0-9]+)", outs).group(1)
-        mnemonic = outs.strip().split('\n')[-1]
+        try:
+            # If output is not json
+            address = re.search(r"address: ([a-z0-9]+)", outs).group(1)
+            pubkey = re.search(r"pubkey: ([a-z0-9]+)", outs).group(1)
+            mnemonic = outs.strip().split('\n')[-1]
+        except Exception as e:
+            print(outs)
+            raise e
 
     except Exception as e:
-        print(e)
-        return
+        print(outs)
+        raise e
 
     res = {
         "address": address,
@@ -132,20 +146,22 @@ def create_wallet(wallet_alias: str, passphrase: str):
     return res
 
 
-def get_wallet_info(wallet_alias: str):
+def get_wallet_info(wallet_alias: str, client_home: str = '.test_clif'):
     """
     clif keys show <wallet_alias>
     """
-    res = _process_executor("clif keys show {}", wallet_alias, need_output=True)
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif keys show {} --home {}", wallet_alias, client_home, need_output=True)
     return res
 
 
-def delete_wallet(wallet_alias: str, passphrase: str):
+def delete_wallet(wallet_alias: str, passphrase: str, client_home: str = '.test_clif'):
     """
     clif key delete <wallet_alias>
     """
+    client_home = os.path.join(os.environ["HOME"], client_home)
     try:
-        child = pexpect.spawn("clif keys delete {}".format(wallet_alias))
+        child = pexpect.spawn("clif keys delete {} --home {}".format(wallet_alias, client_home))
         _ = child.read_nonblocking(10000, timeout=1)
         _ = child.sendline(passphrase)
         
@@ -155,32 +171,35 @@ def delete_wallet(wallet_alias: str, passphrase: str):
         raise FinishedWithError
 
 
-def add_genesis_account(address: str, coin: int, stake: int):
+def add_genesis_account(address: str, coin: int, stake: int, client_home: str = '.test_clif'):
     """
     Will deleted later
 
     nodef add-genesis-account <address> <initial_coin>,<initial_stake>
     """
 
-    _ = _process_executor("nodef add-genesis-account {} {}dummy,{}stake", address, coin, stake)
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    _ = _process_executor("nodef add-genesis-account {} {}dummy,{}stake --home-client {}", address, coin, stake, client_home)
 
 
-def add_el_genesis_account(address: str, coin: int, stake: int):
+def add_el_genesis_account(address: str, coin: int, stake: int, client_home: str = '.test_clif'):
     """
     nodef add-el-genesis-account <address> <initial_coin> <initial_stake>
     """
 
-    _ = _process_executor("nodef add-el-genesis-account {} {} {}", address, coin, stake)
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    _ = _process_executor("nodef add-el-genesis-account {} {} {} --home-client {}", address, coin, stake, client_home)
 
-def clif_configs(chain_id: str):
+def clif_configs(chain_id: str, client_home: str = '.test_clif'):
     """
     clif configs for easy use
     """
+    client_home = os.path.join(os.environ["HOME"], client_home)
     cmds = [
-        "clif config chain-id {}".format(chain_id),
-        "clif config output json",
-        "clif config trust-node true",
-        "clif config indent true"
+        "clif config chain-id {} --home {}".format(chain_id, client_home),
+        "clif config output json --home {}".format(client_home),
+        "clif config trust-node true --home {}".format(client_home),
+        "clif config indent true --home {}".format(client_home)
     ]
 
     for cmd in cmds:
@@ -198,12 +217,13 @@ def load_chainspec():
     _ = _process_executor(cmd, path)
     
 
-def gentx(wallet_alias: str, passphrase: str):
+def gentx(wallet_alias: str, passphrase: str, client_home: str = '.test_clif'):
     """
     nodef gentx --name <wallet_alias>
     """
+    client_home = os.path.join(os.environ["HOME"], client_home)
     try:
-        child = pexpect.spawn("nodef gentx --name {}".format(wallet_alias))
+        child = pexpect.spawn("nodef gentx --name {} --home-client {}".format(wallet_alias, client_home))
         _ = child.read_nonblocking(10000, timeout=1)
         _ = child.sendline(passphrase)
         
@@ -234,13 +254,14 @@ def unsafe_reset_all():
 
 
 def whole_cleanup():
-    for item in [[".nodef", "config"], [".nodef", "data"], [".clif"]]:
+    for item in [[".nodef", "config"], [".nodef", "data"], [".test_clif"]]:
         path = os.path.join(os.environ["HOME"], *item)
         shutil.rmtree(path, ignore_errors=True)
 
 
-def query_tx(tx_hash):
-    res = _process_executor("clif query tx {}", tx_hash, need_output=True)
+def query_tx(tx_hash, client_home: str = ".test_clif"):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif query tx {} --home {}", tx_hash, client_home, need_output=True)
     return res
 
 
@@ -262,16 +283,19 @@ def get_bls_pubkey_remote(remote_address):
 ## Nickname CLI
 #################
 
-def set_nickname(passphrase: str, nickname: str, address: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname set {} --from {} --node {}", passphrase, nickname, address, node)
+def set_nickname(passphrase: str, nickname: str, address: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif nickname set {} --from {} --node {} --home {}", passphrase, nickname, address, node, client_home)
 
 
-def change_address_of_nickname(passphrase: str, nickname: str, new_address: str, old_address: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif nickname change-to {} {} --from {} --node {}", passphrase, nickname, new_address, old_address, node)
+def change_address_of_nickname(passphrase: str, nickname: str, new_address: str, old_address: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif nickname change-to {} {} --from {} --node {} --home {}", passphrase, nickname, new_address, old_address, node, client_home)
 
 
-def get_address(nickname: str, node: str = "tcp://localhost:26657"):
-    res = _process_executor("clif nickname get-address {} --node {}", nickname, node, need_output=True)
+def get_address(nickname: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif nickname get-address {} --node {} --home {}", nickname, node, client_home, need_output=True)
     return res
 
 
@@ -279,23 +303,28 @@ def get_address(nickname: str, node: str = "tcp://localhost:26657"):
 ## Hdac custom CLI
 ##################
 
-def transfer_to(passphrase: str, recipient: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac transfer-to {} {} {} {} --from {} --node {}", passphrase, recipient, amount, fee, gas_price, from_value, node)
+def transfer_to(passphrase: str, recipient: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac transfer-to {} {} {} {} --from {} --node {} --home {}", passphrase, recipient, amount, fee, gas_price, from_value, node, client_home)
 
 
-def bond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac bond {} {} {} --from {} --node {}", passphrase, amount, fee, gas_price, from_value, node)
+def bond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac bond {} {} {} --from {} --node {} --home {}", passphrase, amount, fee, gas_price, from_value, node, client_home)
 
 
-def unbond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac unbond {} {} {} --from {} --node {}", passphrase, amount, fee, gas_price, from_value, node)
+def unbond(passphrase: str, amount: int, fee: int, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac unbond {} {} {} --from {} --node {} --home {}", passphrase, amount, fee, gas_price, from_value, node, client_home)
 
 
-def get_balance(from_value: str, node: str = "tcp://localhost:26657"):
-    res = _process_executor("clif hdac getbalance --from {} --node {}", from_value, node, need_output=True)
+def get_balance(from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac getbalance --from {} --node {} --home {}", from_value, node, client_home, need_output=True)
     return res
 
 
-def create_validator(passphrase: str, from_value: str, pubkey: str, moniker: str, identity: str='""', website: str='""', details: str='""', node: str = "tcp://localhost:26657"):
-    return _tx_executor("clif hdac create-validator --from {} --pubkey {} --moniker {} --identity {} --website {} --details {} --node {}",
-                      passphrase, from_value, pubkey, moniker, identity, website, details, node)
+def create_validator(passphrase: str, from_value: str, pubkey: str, moniker: str, identity: str='""', website: str='""', details: str='""', node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac create-validator --from {} --pubkey {} --moniker {} --identity {} --website {} --details {} --node {} --home {}",
+                      passphrase, from_value, pubkey, moniker, identity, website, details, node, client_home)

--- a/integration_tests/lib/errors.py
+++ b/integration_tests/lib/errors.py
@@ -5,3 +5,7 @@ class DeadDaemonException(Exception):
 class FinishedWithError(Exception):
     def __str__(self):
         return "process was finished with error"
+
+class InvalidContractRunType(Exception):
+    def __str__(self):
+        return "invalid contract run type (valid only 'wasm', 'hash', 'name', or 'uref')"

--- a/integration_tests/test_multi_node_simple_cli.py
+++ b/integration_tests/test_multi_node_simple_cli.py
@@ -270,4 +270,15 @@ class TestMultiNodeSimple:
         #res_transfer = cmd.get_balance("address", self.info_anna['address'], node=picked_node)
         #assert(int(res_transfer['value']) == int(self.basic_coin + self.transfer_amount))
 
+        print("Try to transfer to nickname sender")
+        tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], self.transfer_amount,
+                                           self.transfer_fee, self.transfer_gas, self.nickname_anna)
+
+        print("Tx sent. Waiting for validation")
+        time.sleep(self.tx_blocktime * 3 + 1)
+
+        print("Check Tx OK or not")
+        is_ok = cmd.is_tx_ok(tx_hash_transfer)
+        assert(is_ok == True)
+
         print("======================Done test04_transfer_to_by_nickname======================")

--- a/integration_tests/test_multi_node_simple_cli.py
+++ b/integration_tests/test_multi_node_simple_cli.py
@@ -93,7 +93,7 @@ class TestMultiNodeSimple:
                 zip(self.nodes_address[1:], self.bls_pubkeys[1:], [self.wallet_anna, self.wallet_hans, self.wallet_olaf], self.monikers[1:]):
 
             print("For {}".format(unit_node_address))
-            unit_bond_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, "wallet", unit_wallet_alias)
+            unit_bond_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, unit_wallet_alias)
             bond_hashes.append(unit_bond_hash)
 
         print("Wait for switching next block...")
@@ -139,10 +139,10 @@ class TestMultiNodeSimple:
 
         for node in self.nodes_address[:3]:
             print("Test of {}".format(node))
-            res = cmd.get_balance("wallet", self.wallet_anna, node=node)
+            res = cmd.get_balance(self.wallet_anna, node=node)
             assert("value" in res)
 
-            res = cmd.get_balance("wallet", self.wallet_elsa, node=node)
+            res = cmd.get_balance(self.wallet_elsa, node=node)
             assert("value" in res)
 
             print("{} OK".format(node))
@@ -159,8 +159,7 @@ class TestMultiNodeSimple:
         print("At {}".format(picked_node))
 
         tx_hash = cmd.transfer_to(self.wallet_password, self.info_anna['address'], self.transfer_amount,
-                        self.transfer_fee, self.transfer_gas,
-                        'address', self.info_elsa['address'], node=picked_node)
+                        self.transfer_fee, self.transfer_gas, self.info_elsa['address'], node=picked_node)
 
         print("Tx sent. Waiting for validation")
         time.sleep(self.tx_blocktime * 3 + 1)
@@ -175,12 +174,12 @@ class TestMultiNodeSimple:
         picked_node = self.get_node_randomly()
         print("At {}".format(picked_node))
 
-        res = cmd.get_balance("wallet", self.wallet_anna, node=picked_node)
+        res = cmd.get_balance(self.wallet_anna, node=picked_node)
         assert((self.basic_coin + self.transfer_amount) * 0.95 < int(res["value"]))
 
         picked_node = self.get_node_randomly()
         print("At {}".format(picked_node))
-        res = cmd.get_balance("wallet", self.wallet_elsa, node=picked_node)
+        res = cmd.get_balance(self.wallet_elsa, node=picked_node)
         assert(int(res["value"]) < self.basic_coin - self.transfer_amount)
 
         print("======================Done test01_transfer_to======================")
@@ -193,8 +192,7 @@ class TestMultiNodeSimple:
         print("At {}".format(picked_node))
 
         tx_hash = cmd.transfer_to(self.wallet_password, self.info_bryan['address'], int(self.transfer_amount / 10),
-                        self.transfer_fee, self.transfer_gas,
-                        'address', self.info_anna['address'], node=picked_node)
+                        self.transfer_fee, self.transfer_gas, self.info_anna['address'], node=picked_node)
 
         print("Tx sent. Waiting for validation")
         time.sleep(self.tx_blocktime * 3 + 1)
@@ -212,10 +210,10 @@ class TestMultiNodeSimple:
         # If the query result comes, we can sure that the account exists, although there is no balance assertion.
         for node in self.nodes_address[:3]:
             print("Test of {}".format(node))
-            res = cmd.get_balance("wallet", self.wallet_anna, node=node)
+            res = cmd.get_balance(self.wallet_anna, node=node)
             print("Balance of 'anna': ", int(res["value"]))
 
-            res = cmd.get_balance("wallet", self.wallet_bryan, node=node)
+            res = cmd.get_balance(self.wallet_bryan, node=node)
             print("Balance of 'anna': ", int(res["value"]))
             print("{} OK".format(node))
 
@@ -226,7 +224,7 @@ class TestMultiNodeSimple:
         print("Set nickname")
         picked_node = self.get_node_randomly()
         print("At {}".format(picked_node))
-        tx_hash_nickname = cmd.set_nickname_by_address(self.wallet_password, self.nickname_anna, self.info_anna['address'], node=picked_node)
+        tx_hash_nickname = cmd.set_nickname(self.wallet_password, self.nickname_anna, self.info_anna['address'], node=picked_node)
 
         print("Tx sent. Waiting for validation")
         time.sleep(self.tx_blocktime * 3 + 1)
@@ -259,7 +257,7 @@ class TestMultiNodeSimple:
         print("At {}".format(picked_node))
 
         tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.nickname_anna, self.transfer_amount,
-                                           self.transfer_fee, self.transfer_gas, "wallet", self.wallet_elsa, node=picked_node)
+                                           self.transfer_fee, self.transfer_gas, self.wallet_elsa, node=picked_node)
 
         print("Tx sent. Waiting for validation")
         time.sleep(self.tx_blocktime * 3 + 1)

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -18,6 +18,9 @@ class TestSingleNode():
     wallet_hans = "hans"
     wallet_password = "!friday1234@"
 
+    nickname_elsa = "princesselsa"
+    nickname_anna = "princessanna"
+
     info_elsa = None
     info_anna = None
     info_olaf = None
@@ -34,7 +37,7 @@ class TestSingleNode():
     transfer_fee = 100000000
     transfer_gas = 25000000
 
-    tx_confirm_delay = 10
+    tx_block_time = 6
 
 
     def daemon_healthcheck(self):
@@ -133,11 +136,11 @@ class TestSingleNode():
     def test00_get_balance(self):
         print("======================Start test00_get_balance======================")
 
-        res = cmd.get_balance("wallet", "anna")
+        res = cmd.get_balance(self.wallet_elsa)
         print("Output: ", res)
         assert(int(res["value"]) == self.basic_coin)
 
-        res = cmd.get_balance("wallet", "elsa")
+        res = cmd.get_balance(self.wallet_anna)
         assert(int(res["value"]) == self.basic_coin)
         print("======================Done test00_get_balance======================")
 
@@ -147,21 +150,20 @@ class TestSingleNode():
 
         print("Transfer token from elsa to anna")
         tx_hash = cmd.transfer_to(self.wallet_password, self.info_anna['address'], self.transfer_amount,
-                        self.transfer_fee, self.transfer_gas,
-                        'address', self.info_elsa['address'])
+                        self.transfer_fee, self.transfer_gas, self.info_elsa['address'])
         
         print("Tx sent. Waiting for validation")
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(tx_hash)
         assert(is_ok == True)
 
         print("Balance checking after transfer..")
-        res = cmd.get_balance("wallet", "anna")
+        res = cmd.get_balance(self.wallet_anna)
         assert(int(res["value"]) == self.basic_coin + self.transfer_amount)
 
-        res = cmd.get_balance("wallet", "elsa")
+        res = cmd.get_balance(self.wallet_elsa)
         assert(int(res["value"]) < self.basic_coin - self.transfer_amount)
 
         print("======================Done test01_transfer_to======================")
@@ -172,40 +174,40 @@ class TestSingleNode():
         print("======================Start test02_bond_and_unbond======================")
 
         print("Bonding token")
-        bond_tx_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, "wallet", "anna")
+        bond_tx_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, self.wallet_anna)
         print("Tx sent. Waiting for validation")
 
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(bond_tx_hash)
         assert(is_ok == True)
 
         print("Balance checking after bonding")
-        res_before = cmd.get_balance("wallet", "anna")
+        res_before = cmd.get_balance(self.wallet_anna)
 
         print("Try to send more money than bonding. Invalid tx expected")
         tx_hash_after_bond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before['value']) - self.basic_bond / 2),
-                                             self.transfer_fee, self.transfer_gas, "wallet", "anna")
+                                             self.transfer_fee, self.transfer_gas, self.wallet_anna)
         
         print("Tx sent. Waiting for validation")
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
         
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(tx_hash_after_bond)
         #assert(is_ok == False)
 
         print("Balance checking after bonding")
-        res_after = cmd.get_balance("wallet", "anna")
+        res_after = cmd.get_balance(self.wallet_anna)
         # Reason: Just enough value to ensure that tx become invalid
         assert(self.basic_bond < int(res_after["value"]))
 
         print("Unbond and try to transfer")
         print("Unbond first")
-        tx_hash_unbond = cmd.unbond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, "wallet", "anna")
+        tx_hash_unbond = cmd.unbond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, self.wallet_anna)
         print("Tx sent. Waiting for validation")
 
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(tx_hash_unbond)
@@ -213,42 +215,41 @@ class TestSingleNode():
 
         print("Try to transfer. Will be confirmed in this time")
         tx_hash_after_unbond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before['value']) - self.basic_bond / 2),
-                                               self.transfer_fee, self.transfer_gas, "wallet", "anna")
+                                               self.transfer_fee, self.transfer_gas, self.wallet_anna)
         
         print("Tx sent. Waiting for validation")
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(tx_hash_after_unbond)
         assert(is_ok == True)
 
         print("Balance checking after bonding")
-        res_after_after = cmd.get_balance("wallet", "elsa")
+        res_after_after = cmd.get_balance(self.wallet_anna)
         # Reason: Just enough value to ensure that tx become invalid
         assert(int(res_after_after["value"]) == self.basic_coin + int(res_before['value']) - self.basic_bond)
 
         print("======================Done test02_bond_and_unbond======================")
 
 
-    @pytest.mark.skip(reason="Stable local, will unmark skip and check the err message after master branch merge")
     def test02_1_simple_bond_unbond(self):
         print("======================Start test02_1_simple_bond_unbond======================")
 
         print("Bonding token")
-        bond_tx_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, "wallet", "anna")
+        bond_tx_hash = cmd.bond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, self.wallet_anna)
         print("Tx sent. Waiting for validation")
 
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(bond_tx_hash)
         assert(is_ok == True)
 
         print("Unbonding token")
-        tx_hash_unbond = cmd.unbond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, "wallet", "anna")
+        tx_hash_unbond = cmd.unbond(self.wallet_password, self.basic_bond, self.bonding_fee, self.bonding_gas, self.wallet_anna)
         print("Tx sent. Waiting for validation")
 
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
         is_ok = cmd.is_tx_ok(tx_hash_unbond)
@@ -259,17 +260,17 @@ class TestSingleNode():
 
     def _register_nickname(self):
         print("Set nickname")
-        tx_hash_nickname = cmd.set_nickname_by_address(self.wallet_password, "anna", self.info_anna['address'])
+        tx_hash_nickname = cmd.set_nickname(self.wallet_password, self.nickname_anna, self.info_anna['address'])
 
         print("Tx sent. Waiting for validation")
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether the Tx is OK or not")
         is_ok = cmd.is_tx_ok(tx_hash_nickname)
         assert(is_ok == True)
 
         print("Get registered address and compare to the info from the wallet")
-        res_info = cmd.get_address("anna")
+        res_info = cmd.get_address(self.nickname_anna)
         assert(res_info['address'] == self.info_anna['address'])
 
         print("Well registered!")
@@ -287,19 +288,18 @@ class TestSingleNode():
         self._register_nickname()
 
         print("Try to transfer to nickname recipient")
-        tx_hash_transfer = cmd.transfer_to(self.wallet_password, "anna", self.transfer_amount,
-                                           self.transfer_fee, self.transfer_gas, "wallet", "elsa")
+        tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.nickname_anna, self.transfer_amount,
+                                           self.transfer_fee, self.transfer_gas, self.wallet_elsa)
 
         print("Tx sent. Waiting for validation")
-        time.sleep(self.tx_confirm_delay)
+        time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check Tx OK or not")
         is_ok = cmd.is_tx_ok(tx_hash_transfer)
         assert(is_ok == True)
 
         print("Check wallet by address. Should be match with wallet info")
-        res_transfer = cmd.get_balance("address", self.info_anna['address'])
+        res_transfer = cmd.get_balance(self.info_anna['address'])
         assert(int(res_transfer['value']) == int(self.basic_coin + self.transfer_amount))
 
         print("======================Done test04_transfer_to_by_nickname======================")
-        

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -302,4 +302,19 @@ class TestSingleNode():
         res_transfer = cmd.get_balance(self.info_anna['address'])
         assert(int(res_transfer['value']) == int(self.basic_coin + self.transfer_amount))
 
+        print("Try to transfer to nickname sender")
+        tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], self.transfer_amount,
+                                           self.transfer_fee, self.transfer_gas, self.nickname_anna)
+
+        print("Tx sent. Waiting for validation")
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        print("Check Tx OK or not")
+        is_ok = cmd.is_tx_ok(tx_hash_transfer)
+        assert(is_ok == True)
+
+        print("Check wallet by address. Should be match with wallet info")
+        res_transfer = cmd.get_balance(self.info_anna['address'])
+        assert(int(self.basic_coin *0.9) < int(res_transfer['value']) < self.basic_coin)
+
         print("======================Done test04_transfer_to_by_nickname======================")

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -1,4 +1,6 @@
 import time
+import json
+import os
 
 import pytest
 
@@ -318,3 +320,33 @@ class TestSingleNode():
         assert(int(self.basic_coin *0.9) < int(res_transfer['value']) < self.basic_coin)
 
         print("======================Done test04_transfer_to_by_nickname======================")
+
+    
+    def test05_custom_contract_execution(self):
+        print("======================Start test05_custom_contract_execution======================")
+        print("Run store system contract")
+
+        print("Try to run bond function by wasm path")
+        wasm_path = os.path.join(os.environ['HOME'], ".nodef", "contracts", "bonding.wasm")
+        param = json.dumps([
+            # {
+            #       "name": "method_name",
+            #       "value": {
+            #         "string_value": "bond"
+            #       }
+            # },
+            {
+                "name": "amount",
+                "value": {
+                    "int_value":1000000
+                }
+            }
+        ])
+        tx_hash_store_contract = cmd.run_contract(self.wallet_password, "wasm", wasm_path, param, 100000000, 50000000, self.wallet_anna)
+        print("Tx sent. Waiting for validation")
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        print("Check Tx OK or not")
+        is_ok = cmd.is_tx_ok(tx_hash_store_contract)
+        assert(is_ok == True)
+        print("======================End test05_custom_contract_execution======================")

--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -7,14 +7,15 @@ if [ ${PWD##*/} != "friday" ]; then
   exit 1
 fi
 
-CASPERLABS_TARGET_TAG="v0.10.0"
+TARGET_BRANCH="master"
+COMMIT_HASH="8733f52719eb7bbca8ee6f10996d11f461f8ec66"
 if [ ! -d "CasperLabs/.git" ]; then
-  git clone --single-branch --branch $CASPERLABS_TARGET_TAG https://github.com/CasperLabs/CasperLabs.git
+  git clone --single-branch --branch $TARGET_BRANCH https://github.com/hdac-io/CasperLabs.git
 fi
 
 cd CasperLabs
-git fetch origin refs/tags/$CASPERLABS_TARGET_TAG:refs/tags/$CASPERLABS_TARGET_TAG
-git checkout $CASPERLABS_TARGET_TAG
+git fetch origin $TARGET_BRANCH
+git reset --hard $COMMIT_HASH
 
 cd execution-engine
 make setup
@@ -25,10 +26,6 @@ declare -a TARGET_CONTRACTS=(
   "pos-install"
   "counter-call"
   "counter-define"
-  "standard-payment"
-  "transfer-to-account"
-  "bonding"
-  "unbonding"
 )
 
 declare -a WASM_FILES=(
@@ -36,14 +33,10 @@ declare -a WASM_FILES=(
   "pos_install.wasm"
   "counter_call.wasm"
   "counter_define.wasm"
-  "standard_payment.wasm"
-  "transfer_to_account.wasm"
-  "bonding.wasm"
-  "unbonding.wasm"
 )
 
 for pkg in "${TARGET_CONTRACTS[@]}"; do
-  make build-contract/$pkg
+  make build-contract-rs/$pkg
 done
 
 CONTRACT_DIR="$HOME/.nodef/contracts"

--- a/x/executionlayer/client/cli/flags.go
+++ b/x/executionlayer/client/cli/flags.go
@@ -5,30 +5,17 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/x/executionlayer/types"
 )
 
 // nolint
 const (
-	FlagAddressValidator     = "validator"
-	FlagAddressValidatorSrc  = "addr-validator-source"
-	FlagAddressValidatorDst  = "addr-validator-dest"
-	FlagPubKey               = "pubkey"
-	FlagTokenContractAddress = "token-contract-address"
-	FlagBech32PubKey         = sdk.Bech32MainPrefix + "pub"
-	FlagAmount               = "amount"
-	FlagFee                  = "fee"
-	FlagGasPrice             = "gas-price"
-	FlagBlockHash            = "blockhash"
-	FlagConsPubKey           = "cons-" + FlagPubKey
-	FlagConsBech32PubKey     = "cons-" + FlagBech32PubKey
-	FlagValPubkey            = "val-" + FlagPubKey
-	FlagValBech32PubKey      = "val-" + FlagBech32PubKey
+	FlagAddressValidator    = "validator"
+	FlagAddressValidatorSrc = "addr-validator-source"
+	FlagAddressValidatorDst = "addr-validator-dest"
+	FlagPubKey              = "pubkey"
 
-	FlagWallet   = "wallet"
-	FlagAddress  = "address"
-	FlagNickname = "nickname"
+	FlagBlockHash = "blockhash"
 
 	FlagMoniker  = "moniker"
 	FlagIdentity = "identity"
@@ -55,7 +42,6 @@ var (
 
 func init() {
 	FsPk.String(FlagPubKey, "", "The Bech32 encoded PubKey of the validator")
-	FsAmount.String(FlagAmount, "", "Amount of coins to bond")
 	fsDescriptionCreate.String(FlagMoniker, "", "The validator's name")
 	fsDescriptionCreate.String(FlagIdentity, "", "The optional identity signature (ex. UPort or Keybase)")
 	fsDescriptionCreate.String(FlagWebsite, "", "The validator's (optional) website")

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -86,23 +86,6 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("type must be one of wasm, name, uref, or hash")
 			}
 
-			var sessionAbi []byte
-			if args[2] == "" {
-				sessionAbi, err = cliutil.ProtobufSafeDecodeingHexString(args[2])
-				if err != nil {
-					return err
-				}
-			} else {
-				sessionArgs, err := util.JsonStringToDeployArgs(args[2])
-				if err != nil {
-					return err
-				}
-				sessionAbi, err = util.AbiDeployArgsTobytes(sessionArgs)
-				if err != nil {
-					return err
-				}
-			}
-
 			fee, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				return err
@@ -119,7 +102,7 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				fromAddr,
 				sessionType,
 				sessionCode,
-				sessionAbi,
+				args[2],
 				fee,
 				gasPrice,
 			)

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -20,7 +20,7 @@ import (
 
 func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run <type> <wasm-path>|<uref>|<name>|<hash> <argument> <fee> <gas_price> --wallet|--address|--nickname <from>",
+		Use:   "run <type> <wasm-path>|<uref>|<name>|<hash> <argument> <fee> <gas_price> --from <from>",
 		Short: "Run contract",
 		Long: "Run contract\n" +
 			"There are 4 types of contract run. ('wasm', 'uref', 'name', 'hash)",
@@ -29,48 +29,18 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			// Extract "from" from flags
-			var fromAddr sdk.AccAddress
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
 			}
 
-			if walletname := viper.GetString(FlagWallet); walletname != "" {
-				key, err := kb.Get(walletname)
-				if err != nil {
-					return err
-				}
-
-				fromAddr = key.GetAddress()
-				cliCtx = cliCtx.WithFromAddress(fromAddr).WithFromName(key.GetName())
-			} else if straddr := viper.GetString(FlagAddress); straddr != "" {
-				fromAddr, err = sdk.AccAddressFromBech32(straddr)
-				if err != nil {
-					return fmt.Errorf("malformed address in --address: %s\n%s", straddr, err.Error())
-				}
-
-				key, err := kb.GetByAddress(fromAddr)
-				if err != nil {
-					return err
-				}
-
-				cliCtx = cliCtx.WithFromAddress(fromAddr).WithFromName(key.GetName())
-			} else if nickname := viper.GetString(FlagNickname); nickname != "" {
-				fromAddr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, nickname)
-				if err != nil {
-					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
-				}
-
-				key, err := kb.GetByAddress(fromAddr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(fromAddr).WithFromName(key.GetName())
-			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
 			}
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
+			fromAddr := keyInfo.GetAddress()
 
 			sessionType := cliutil.GetContractType(args[0])
 			var sessionCode []byte
@@ -112,9 +82,7 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
-	cmd.Flags().String(FlagAddress, "", "Bech32 endocded address (fridayxxxxxx..)")
-	cmd.Flags().String(FlagWallet, "", "Wallet alias")
-	cmd.Flags().String(FlagNickname, "", "Nickname")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
 
 	return cmd
 }
@@ -122,11 +90,10 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 // GetCmdTransfer is the CLI command for transfer
 func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "transfer-to <recipient_nickname>|<address> <amount> <fee> <gas_price> --wallet|--address|--nickname <from>",
+		Use:   "transfer-to <recipient_nickname>|<address> <amount> <fee> <gas_price> --from <from>",
 		Short: "Transfer Hdac token",
-		Long: "Transfer Hdac token\n" +
-			"It needs at least one of '--wallet', '--address', or '--nickname' flag.",
-		Args: cobra.ExactArgs(4),
+		Long:  "Transfer Hdac token",
+		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -155,9 +122,6 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			// Extract "from" from flags
-			var fromAddr sdk.AccAddress
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
@@ -168,6 +132,7 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			fromAddr := keyInfo.GetAddress()
 
 			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
 
@@ -188,7 +153,7 @@ func GetCmdTransfer(cdc *codec.Codec) *cobra.Command {
 // GetCmdBonding is the CLI command for bonding
 func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bond --wallet|--address|--nickname <from> <amount> <fee> <gas-price>",
+		Use:   "bond --from <from> <amount> <fee> <gas-price>",
 		Short: "Bond token",
 		Long:  "Bond token for useful activity",
 		Args:  cobra.ExactArgs(3),
@@ -196,47 +161,19 @@ func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			var addr sdk.AccAddress
-			var err error
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
 			}
 
-			// Extract "from" from flags
-			if walletname := viper.GetString(FlagWallet); walletname != "" {
-				key, err := kb.Get(walletname)
-				if err != nil {
-					return err
-				}
-
-				addr = key.GetAddress()
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if straddr := viper.GetString(FlagAddress); straddr != "" {
-				addr, err = sdk.AccAddressFromBech32(straddr)
-				if err != nil {
-					return fmt.Errorf("malformed address in --address: %s\n%s", straddr, err.Error())
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if nickname := viper.GetString(FlagNickname); nickname != "" {
-				addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, nickname)
-				if err != nil {
-					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
-				}
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
 			}
+
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
+			addr := keyInfo.GetAddress()
 
 			// Numbers parsing
 			amount, err := strconv.ParseUint(args[0], 10, 64)
@@ -261,9 +198,7 @@ func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
-	cmd.Flags().String(FlagAddress, "", "Bech32 endocded address (fridayxxxxxx..)")
-	cmd.Flags().String(FlagWallet, "", "Wallet alias")
-	cmd.Flags().String(FlagNickname, "", "Nickname")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
 
 	return cmd
 }
@@ -271,7 +206,7 @@ func GetCmdBonding(cdc *codec.Codec) *cobra.Command {
 // GetCmdUnbonding is the CLI command for unbonding
 func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unbond --wallet|--address|--nickname <from> <amount> <fee> <gas-price>",
+		Use:   "unbond --from <from> <amount> <fee> <gas-price>",
 		Short: "Unbond token",
 		Long:  "Unbond token for converts tokens as a freedom",
 		Args:  cobra.ExactArgs(3),
@@ -279,48 +214,19 @@ func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			var addr sdk.AccAddress
-			var err error
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
 			}
 
-			// Extract "from" from flags
-			if walletname := viper.GetString(FlagWallet); walletname != "" {
-				key, err := kb.Get(walletname)
-				if err != nil {
-					return err
-				}
-
-				addr = key.GetAddress()
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if straddr := viper.GetString(FlagAddress); straddr != "" {
-				addr, err = sdk.AccAddressFromBech32(straddr)
-				if err != nil {
-					return fmt.Errorf("malformed address in --address: %s\n%s", straddr, err.Error())
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if nickname := viper.GetString(FlagNickname); nickname != "" {
-				addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, nickname)
-				if err != nil {
-					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
 			}
+
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
+			addr := keyInfo.GetAddress()
 
 			// Numbers parsing
 			amount, err := strconv.ParseUint(args[0], 10, 64)
@@ -336,8 +242,6 @@ func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			cliCtx = cliCtx.WithFromAddress(addr)
-
 			// build and sign the transaction, then broadcast to Tendermint
 			// TODO: Currently implementation of contract address is dummy
 			msg := types.NewMsgUnBond("dummyAddress", addr, amount, fee, gasPrice)
@@ -347,9 +251,7 @@ func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
-	cmd.Flags().String(FlagAddress, "", "Bech32 endocded address (fridayxxxxxx..)")
-	cmd.Flags().String(FlagWallet, "", "Wallet alias")
-	cmd.Flags().String(FlagNickname, "", "Nickname")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
 
 	return cmd
 }
@@ -357,57 +259,25 @@ func GetCmdUnbonding(cdc *codec.Codec) *cobra.Command {
 // GetCmdCreateValidator implements the create validator command handler.
 func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "create-validator --wallet|--address|--nickname <from> --pubkey <validator_cons_pubkey> " +
+		Use: "create-validator --from <from> --pubkey <validator_cons_pubkey> " +
 			"[--moniker <moniker>] [--identity <identity>] [--website <site_address>] [--details <detail_description>]",
 		Short: "create new validator initialized with a self-delegation to it",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			var addr sdk.AccAddress
-			var err error
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
 			}
 
-			// Extract "from" from flags
-			if walletname := viper.GetString(FlagWallet); walletname != "" {
-				key, err := kb.Get(walletname)
-				if err != nil {
-					return err
-				}
-
-				addr = key.GetAddress()
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if straddr := viper.GetString(FlagAddress); straddr != "" {
-				addr, err = sdk.AccAddressFromBech32(straddr)
-				if err != nil {
-					return fmt.Errorf("malformed address in --address: %s\n%s", straddr, err.Error())
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if nickname := viper.GetString(FlagNickname); nickname != "" {
-				addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, nickname)
-				if err != nil {
-					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
 			}
 
-			cliCtx = cliCtx.WithFromAddress(addr)
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
 
 			msg, err := BuildCreateValidatorMsg(cliCtx)
 			if err != nil {
@@ -419,9 +289,7 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
-	cmd.Flags().String(FlagAddress, "", "Bech32 endocded address (fridayxxxxxx..)")
-	cmd.Flags().String(FlagWallet, "", "Wallet alias")
-	cmd.Flags().String(FlagNickname, "", "Nickname")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
 	cmd.Flags().AddFlagSet(fsDescriptionCreate)
 	cmd.Flags().AddFlagSet(FsPk)
 
@@ -434,57 +302,24 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 // GetCmdEditValidator implements the create edit validator command.
 func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "edit-validator --wallet|--address|--nickname <from> " +
+		Use: "edit-validator --from <from> " +
 			"[--moniker <moniker>] [--identity <identity>] [--website <site_address>] [--details <detail_description>]",
 		Short: "edit an existing validator account",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			var addr sdk.AccAddress
-			var err error
-
 			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
 			if err != nil {
 				return err
 			}
 
-			// Extract "from" from flags
-			if walletname := viper.GetString(FlagWallet); walletname != "" {
-				key, err := kb.Get(walletname)
-				if err != nil {
-					return err
-				}
-
-				addr = key.GetAddress()
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if straddr := viper.GetString(FlagAddress); straddr != "" {
-				addr, err = sdk.AccAddressFromBech32(straddr)
-				if err != nil {
-					return fmt.Errorf("malformed address in --address: %s\n%s", straddr, err.Error())
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else if nickname := viper.GetString(FlagNickname); nickname != "" {
-				addr, err = cliutil.GetAddress(cliCtx.Codec, cliCtx, nickname)
-				if err != nil {
-					return fmt.Errorf("no registered address of the given nickname '%s'", nickname)
-				}
-
-				key, err := kb.GetByAddress(addr)
-				if err != nil {
-					return err
-				}
-				cliCtx = cliCtx.WithFromAddress(addr).WithFromName(key.GetName())
-			} else {
-				return fmt.Errorf("one of --address, --wallet, --nickname is essential")
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
 			}
-
-			cliCtx = cliCtx.WithFromAddress(addr)
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
 
 			valAddr := cliCtx.GetFromAddress()
 			description := types.Description{
@@ -502,9 +337,7 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
-	cmd.Flags().String(FlagAddress, "", "Bech32 endocded address (fridayxxxxxx..)")
-	cmd.Flags().String(FlagWallet, "", "Wallet alias")
-	cmd.Flags().String(FlagNickname, "", "Nickname")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
 
 	cmd.Flags().AddFlagSet(fsDescriptionEdit)
 

--- a/x/executionlayer/client/util/util.go
+++ b/x/executionlayer/client/util/util.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/client/context"
 	"github.com/hdac-io/friday/codec"
+	"github.com/hdac-io/friday/crypto/keys"
 	sdk "github.com/hdac-io/friday/types"
 	idtype "github.com/hdac-io/friday/x/nickname/types"
 )
@@ -63,4 +64,47 @@ func ProtobufSafeDecodeingHexString(str string) ([]byte, error) {
 	}
 
 	return res, nil
+}
+
+// GetLocalWalletInfo takes wallet info from local
+// Rules:
+// 1) If --from exists, search according to:
+//  (1) Local wallet alias
+//  (2) Address
+//  (3) Nickname
+// 2) If --from doesn't exist,
+//  (1) If only one wallet exists, take this
+//  (2) If not, raise error
+func GetLocalWalletInfo(valueFromFromFlag string, kb keys.Keybase, cdc *codec.Codec, cliCtx context.CLIContext) (keys.Info, error) {
+	if valueFromFromFlag != "" {
+		// Find in local wallet
+		key, err := kb.Get(valueFromFromFlag)
+		if err == nil {
+			return key, nil
+		}
+
+		// If not exist, try parsing into address and find in nickname
+		addr, err := GetAddress(cdc, cliCtx, valueFromFromFlag)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse into address, or no registered address of the given nickname '%s'", valueFromFromFlag)
+		}
+		key, err = kb.GetByAddress(addr)
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+
+	infoList, err := kb.List()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(infoList) > 1 {
+		return nil, fmt.Errorf("multiple wallets in local. Cannot specify one wallet")
+	} else if len(infoList) == 0 {
+		return nil, fmt.Errorf("no wallet in local")
+	}
+
+	return infoList[0], nil
 }

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -2,12 +2,9 @@ package executionlayer
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc/transforms"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
@@ -46,7 +43,12 @@ func NewHandler(k ExecutionLayerKeeper) sdk.Handler {
 //   1) Raw account is needed for checking address existence
 //   2) Fixed transfer & payment WASMs are needed
 func handlerMsgTransfer(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgTransfer) sdk.Result {
+	proxyContractHash := k.GetProxyContractHash(ctx)
 	sessionArgs := []*consensus.Deploy_Arg{
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.TransferMethodName}}},
 		&consensus.Deploy_Arg{
 			Value: &consensus.Deploy_Arg_Value{
 				Value: &consensus.Deploy_Arg_Value_BytesValue{
@@ -57,18 +59,17 @@ func handlerMsgTransfer(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgTr
 					LongValue: int64(msg.Amount)}}},
 	}
 
-	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	sessionArgsStr, err := DeployArgsToJsonString(sessionArgs)
 	if err != nil {
-		return getResult(false, err.Error())
+		getResult(false, err.Error())
 	}
 
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
-		// TODO Will be change store contract call
-		util.WASM,
-		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/transfer_to_account.wasm")),
-		sessionAbi,
+		util.HASH,
+		proxyContractHash,
+		sessionArgsStr,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -121,25 +122,28 @@ func handlerMsgEditValidator(ctx sdk.Context, k ExecutionLayerKeeper, msg types.
 }
 
 func handlerMsgBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgBond) sdk.Result {
+	proxyContractHash := k.GetProxyContractHash(ctx)
 	sessionArgs := []*consensus.Deploy_Arg{
 		&consensus.Deploy_Arg{
 			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.BondMethodName}}},
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
 				Value: &consensus.Deploy_Arg_Value_LongValue{
-					LongValue: int64(msg.Amount)}}},
-	}
+					LongValue: int64(msg.Amount)}}}}
 
-	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	sessionArgsStr, err := DeployArgsToJsonString(sessionArgs)
 	if err != nil {
-		return getResult(false, err.Error())
+		getResult(false, err.Error())
 	}
 
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
-		// TODO Will be change store contract call
-		util.WASM,
-		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/bonding.wasm")),
-		sessionAbi,
+		util.HASH,
+		proxyContractHash,
+		sessionArgsStr,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -148,7 +152,12 @@ func handlerMsgBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgBond) 
 }
 
 func handlerMsgUnBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnBond) sdk.Result {
+	proxyContractHash := k.GetProxyContractHash(ctx)
 	sessionArgs := []*consensus.Deploy_Arg{
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.UnbondMethodName}}},
 		&consensus.Deploy_Arg{
 			Value: &consensus.Deploy_Arg_Value{
 				Value: &consensus.Deploy_Arg_Value_OptionalValue{
@@ -156,18 +165,17 @@ func handlerMsgUnBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnBo
 						Value: &consensus.Deploy_Arg_Value_LongValue{
 							LongValue: int64(msg.Amount)}}}}}}
 
-	sessionAbi, err := util.AbiDeployArgsTobytes(sessionArgs)
+	sessionArgsStr, err := DeployArgsToJsonString(sessionArgs)
 	if err != nil {
-		return getResult(false, err.Error())
+		getResult(false, err.Error())
 	}
 
 	msgExecute := NewMsgExecute(
 		msg.ContractAddress,
 		msg.FromAddress,
-		// TODO Will be change store contract call
-		util.WASM,
-		util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/unbonding.wasm")),
-		sessionAbi,
+		util.HASH,
+		proxyContractHash,
+		sessionArgsStr,
 		msg.Fee,
 		msg.GasPrice,
 	)
@@ -177,31 +185,41 @@ func handlerMsgUnBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnBo
 }
 
 func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute) (bool, string) {
-
+	proxyContractHash := k.GetProxyContractHash(ctx)
 	// Parameter preparation
 	stateHash := ctx.CandidateBlock().State
 	protocolVersion := k.MustGetProtocolVersion(ctx)
 	log := ""
 
+	sessionArgs := []*consensus.Deploy_Arg{}
+	var err error
+	if msg.SessionArgs != "" {
+		sessionArgs, err = util.JsonStringToDeployArgs(msg.SessionArgs)
+		if err != nil {
+			return false, err.Error()
+		}
+	}
+
 	paymentArgs := []*consensus.Deploy_Arg{
 		&consensus.Deploy_Arg{
 			Value: &consensus.Deploy_Arg_Value{
-				Value: &consensus.Deploy_Arg_Value_BigInt{
-					BigInt: &state.BigInt{
-						Value:    strconv.FormatUint(msg.Fee, 10),
-						BitWidth: 512}}}}}
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.PaymentMethodName}}},
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_IntValue{
+					IntValue: int32(msg.Fee)}}}}
 
-	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
+	// Execute
+	deploys := []*ipc.DeployItem{}
+	deploy, err := util.MakeDeploy(
+		msg.ExecAddress.ToEEAddress(),
+		msg.SessionType, msg.SessionCode, sessionArgs,
+		util.HASH, proxyContractHash, paymentArgs,
+		msg.GasPrice, ctx.BlockTime().Unix(), ctx.ChainID())
 	if err != nil {
 		return false, err.Error()
 	}
-	// Execute
-	deploys := []*ipc.DeployItem{}
-	deploy := util.MakeDeploy(
-		ProtobufSafeEncodeBytes(msg.ExecAddress.ToEEAddress()),
-		msg.SessionType, ProtobufSafeEncodeBytes(msg.SessionCode), ProtobufSafeEncodeBytes(msg.SessionArgs),
-		util.WASM, util.LoadWasmFile(os.ExpandEnv("$HOME/.nodef/contracts/standard_payment.wasm")), paymentAbi,
-		msg.GasPrice, ctx.BlockTime().Unix(), ctx.ChainID())
 	deploys = append(deploys, deploy)
 	reqExecute := &ipc.ExecuteRequest{
 		ParentStateHash: stateHash,

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -298,3 +298,17 @@ func (k ExecutionLayerKeeper) GetAllValidators(ctx sdk.Context) (validators []ty
 }
 
 // -----------------------------------------------------------------------------------------------------------
+
+// GetProxyContractHash retrieves proxy_contract_hash
+func (k ExecutionLayerKeeper) GetProxyContractHash(ctx sdk.Context) []byte {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	proxyContractHash := store.Get([]byte(types.ProxyContractHashKey))
+
+	return proxyContractHash
+}
+
+// SetProxyContractHash save proxy_contract_hash value.
+func (k ExecutionLayerKeeper) SetProxyContractHash(ctx sdk.Context, contractHash []byte) {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	store.Set([]byte(types.ProxyContractHashKey), contractHash)
+}

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -101,7 +101,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterDefineWasm)),
-		[]byte{},
+		"",
 		uint64(100000000),
 		uint64(10),
 	)
@@ -121,7 +121,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterCallWasm)),
-		[]byte{},
+		"",
 		uint64(100000000),
 		uint64(10),
 	)
@@ -189,7 +189,7 @@ func TestTransfer(t *testing.T) {
 
 func TestMarsahlAndUnMarshal(t *testing.T) {
 	src := &transforms.TransformEntry{
-		Transform: &transforms.Transform{TransformInstance: &transforms.Transform_Write{Write: &transforms.TransformWrite{Value: &state.Value{Value: &state.Value_IntValue{IntValue: 1}}}}}}
+		Transform: &transforms.Transform{TransformInstance: &transforms.Transform_Write{Write: &transforms.TransformWrite{Value: &state.StoredValue{Variants: &state.StoredValue_ClValue{ClValue: &state.CLValue{ClType: &state.CLType{Variants: &state.CLType_SimpleType{SimpleType: state.CLType_BOOL}}, SerializedValue: []byte{1, 2, 3}}}}}}}}
 	bz, _ := proto.Marshal(src)
 
 	obj := &transforms.TransformEntry{}
@@ -263,4 +263,15 @@ func TestValidator(t *testing.T) {
 
 	validators := input.elk.GetAllValidators(input.ctx)
 	assert.Equal(t, 1, len(validators))
+}
+
+func TestProxyContractKeeper(t *testing.T) {
+	input := setupTestInput()
+
+	contractHash := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	input.elk.SetProxyContractHash(input.ctx, contractHash)
+
+	res := input.elk.GetProxyContractHash(input.ctx)
+
+	assert.Equal(t, contractHash, res)
 }

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/codec"
 	"github.com/hdac-io/friday/store"
@@ -117,32 +116,51 @@ func genesis(input testInput) []byte {
 	candidateBlock.Hash = []byte{}
 	candidateBlock.State = response.GetSuccess().PoststateHash
 
+	systemAccount := make([]byte, 32)
+	res, errStr := grpc.Query(input.elk.client, candidateBlock.State, "address", systemAccount, []string{}, genesisConfig.GetProtocolVersion())
+	if errStr != "" {
+		panic(errStr)
+	}
+
+	proxyContractHash := []byte{}
+	for _, namedKey := range res.GetAccount().GetNamedKeys() {
+		if namedKey.GetName() == types.ProxyContractName {
+			proxyContractHash = namedKey.GetKey().GetHash().GetHash()
+			break
+		}
+	}
+
+	if len(proxyContractHash) != 32 {
+		panic(fmt.Sprintf("%s must exist. Check systemcontract.", types.ProxyContractName))
+	}
+
+	input.elk.SetProxyContractHash(input.ctx, proxyContractHash)
+
 	return response.GetSuccess().PoststateHash
 }
 
 func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	input := setupTestInput()
+	proxyHash := keeper.GetProxyContractHash(input.ctx)
 	timestamp := time.Now().Unix()
 	paymentArgs := []*consensus.Deploy_Arg{
 		&consensus.Deploy_Arg{
-			Name: "fee",
 			Value: &consensus.Deploy_Arg_Value{
-				Value: &consensus.Deploy_Arg_Value_BigInt{
-					BigInt: &state.BigInt{
-						Value:    "100000000",
-						BitWidth: 512,
-					}}}}}
-	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
-	if err != nil {
-		panic(fmt.Sprintf("fail to convert payment abi: %s", err.Error()))
-	}
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.PaymentMethodName}}},
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_IntValue{
+					IntValue: 100000000}}}}
 	cntDefCode := util.LoadWasmFile(path.Join(contractPath, counterDefineWasm))
-	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
 	genesisAddr := input.elk.GetGenesisAccounts(input.ctx)[0]
 
-	deploy := util.MakeDeploy(genesisAddr.Address.ToEEAddress(), util.WASM, cntDefCode, []byte{},
-		util.WASM, standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
+	deploy, err := util.MakeDeploy(genesisAddr.Address.ToEEAddress(), util.WASM, cntDefCode, []*consensus.Deploy_Arg{},
+		util.WASM, proxyHash, paymentArgs, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
+	if err != nil {
+		panic(fmt.Sprintf("fail to make deploy error : %s", err.Error()))
+	}
 
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
@@ -163,28 +181,27 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 
 func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 	input := setupTestInput()
+	proxyHash := keeper.GetProxyContractHash(input.ctx)
 	timestamp := time.Now().Unix()
 	paymentArgs := []*consensus.Deploy_Arg{
 		&consensus.Deploy_Arg{
-			Name: "fee",
 			Value: &consensus.Deploy_Arg_Value{
-				Value: &consensus.Deploy_Arg_Value_BigInt{
-					BigInt: &state.BigInt{
-						Value:    "100000000",
-						BitWidth: 512,
-					}}}}}
-	paymentAbi, err := util.AbiDeployArgsTobytes(paymentArgs)
-	if err != nil {
-		panic(fmt.Sprintf("fail to convert payment abi: %s", err.Error()))
-	}
+				Value: &consensus.Deploy_Arg_Value_StringValue{
+					StringValue: types.PaymentMethodName}}},
+		&consensus.Deploy_Arg{
+			Value: &consensus.Deploy_Arg_Value{
+				Value: &consensus.Deploy_Arg_Value_IntValue{
+					IntValue: 100000000}}}}
 	cntCallCode := util.LoadWasmFile(path.Join(contractPath, counterCallWasm))
-	standardPaymentCode := util.LoadWasmFile(path.Join(contractPath, standardPaymentWasm))
 	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
 	genesisAddr := input.elk.GetGenesisAccounts(input.ctx)[0]
 
 	timestamp = time.Now().Unix()
-	deploy := util.MakeDeploy(genesisAddr.Address.ToEEAddress(), util.WASM, cntCallCode,
-		[]byte{}, util.WASM, standardPaymentCode, paymentAbi, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
+	deploy, err := util.MakeDeploy(genesisAddr.Address.ToEEAddress(), util.WASM, cntCallCode, []*consensus.Deploy_Arg{},
+		util.HASH, proxyHash, paymentArgs, uint64(10), timestamp, input.elk.GetChainName(input.ctx))
+	if err != nil {
+		panic(fmt.Sprintf("fail to make deploy error : %s", err.Error()))
+	}
 	deploys := util.MakeInitDeploys()
 	deploys = util.AddDeploy(deploys, deploy)
 

--- a/x/executionlayer/types/key.go
+++ b/x/executionlayer/types/key.go
@@ -12,10 +12,11 @@ const (
 	HashMapStoreKey = ModuleName + "_hashmap"
 
 	// key value
-	GenesisBlockHashKey = "genesisblockhash"
-	GenesisConfigKey    = "genesisconf"
-	GenesisAccountKey   = "genesisaccount"
-	CandidateBlockKey   = "candidateblock"
+	GenesisBlockHashKey  = "genesisblockhash"
+	GenesisConfigKey     = "genesisconf"
+	GenesisAccountKey    = "genesisaccount"
+	CandidateBlockKey    = "candidateblock"
+	ProxyContractHashKey = "proxycontractkey"
 )
 
 var (

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -17,7 +17,7 @@ type MsgExecute struct {
 	ExecAddress     sdk.AccAddress    `json:"exec_address"`
 	SessionType     util.ContractType `json:"session_type"`
 	SessionCode     []byte            `json:"session_code"`
-	SessionArgs     []byte            `json:"session_args"`
+	SessionArgs     string            `json:"session_args"`
 	Fee             uint64            `json:"fee"`
 	GasPrice        uint64            `json:"gas_price"`
 }
@@ -27,7 +27,8 @@ func NewMsgExecute(
 	contractAddress string,
 	execAddress sdk.AccAddress,
 	sessionType util.ContractType,
-	sessionCode, sessionArgs []byte,
+	sessionCode []byte,
+	sessionArgs string,
 	fee, gasPrice uint64,
 ) MsgExecute {
 	return MsgExecute{

--- a/x/executionlayer/types/types.go
+++ b/x/executionlayer/types/types.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+const (
+	ProxyContractName  = "client_api_proxy"
+	TransferMethodName = "transfer_to_account"
+	PaymentMethodName  = "standard_payment"
+	BondMethodName     = "bond"
+	UnbondMethodName   = "unbond"
+)
+
 // UnitHashMap used to define Unit account structure
 type UnitHashMap struct {
 	EEState []byte `json:"ee_state"`

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -1,10 +1,11 @@
 package executionlayer
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/x/nickname"
 )
@@ -41,10 +42,20 @@ func toBytes(keyType string, key string,
 	return bytes, nil
 }
 
-func ProtobufSafeEncodeBytes(src []byte) []byte {
-	if bytes.Equal(src, []byte("empty")) {
-		src = []byte{}
+func DeployArgsToJsonString(args []*consensus.Deploy_Arg) (string, error) {
+	m := &jsonpb.Marshaler{}
+	str := "["
+	for idx, arg := range args {
+		if idx != 0 {
+			str += ","
+		}
+		s, err := m.MarshalToString(arg)
+		if err != nil {
+			return "", err
+		}
+		str += s
 	}
+	str += "]"
 
-	return src
+	return str, nil
 }

--- a/x/nickname/client/cli/flags.go
+++ b/x/nickname/client/cli/flags.go
@@ -4,11 +4,6 @@ import (
 	"os"
 )
 
-const (
-	FlagAddress = "address"
-	FlagWallet  = "wallet"
-)
-
 var (
 	DefaultClientHome = os.ExpandEnv("$HOME/.clif")
 )


### PR DESCRIPTION
### Update

#### Before
  * Key is specified by `--wallet`, `--address`, and `--nickname` flags

#### After
  * Unified that to `--from`

#### Searching rule
  1. No `--from`
    - Check the # of the local wallet
      * If only 1, use this
      * If none or multiple, raise error
  1. With `--from`
    - Search by following priority:
      1. Local wallet alias
      1. Address parsing
      1. Querying to nickname module

#### Modified logic
* Modified address shipping rule in client context
* Modified key selection rule in each CLI
* Reduced recurring code and put it into util

### How to review

  * `clif nickname set princesselsa --from elsa`
  * `clif nickname set princesselsa` if only `elsa` exists
  * `clif nickname change-to princesselsa fridayxxxxxxxx... --from elsa`
  * `clif hdac transfer-to princessanna 1000000 100000000 25000000 --from elsa`
  * `clif hdac transfer-to princessanna 1000000 100000000 25000000` if only `elsa` exists
  * `clif hdac bond/unbond 10000000000 1000000000 50000000 --from elsa`
  * `clif hdac bond/unbond 10000000000 1000000000 50000000` if only `elsa` exists
  * `clif hdac create-validator --from elsa --pubkey fridayvalconspubxxxxx --moniker node1`
  * `clif hdac create-validator --pubkey fridayvalconspubxxxxx --moniker node1` if only `elsa` exists

Multinode test has been passed. [Test log](http://132.145.81.228:8080/job/05_(Do%20not%20trigger%20yourself)%20Test%20run/36/console)