### PR TITLE
feat: support stored contract

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0 h1:J8fsIADiXvFg62YC9COkkD66u+CtZQeBIbPPbfTFu9I=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c h1:p7U9ltB4TV5xEn9cDdQ9FkiuPRLYv100tys4oo/n4Rg=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c h1:p7U9ltB4TV5xEn9cDdQ9FkiuPRLYv100tys4oo/n4Rg=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.2.1-0.20200220084106-06f16e84cf6c/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0 h1:IJKTCuAZq/wHXgGTl6kX6PUcbGtjpdDKMGyvoI7ACTQ=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.3.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -7,14 +7,15 @@ if [ ${PWD##*/} != "friday" ]; then
   exit 1
 fi
 
-CASPERLABS_TARGET_TAG="v0.10.0"
+TARGET_BRANCH="master"
+COMMIT_HASH="8733f52719eb7bbca8ee6f10996d11f461f8ec66"
 if [ ! -d "CasperLabs/.git" ]; then
-  git clone --single-branch --branch $CASPERLABS_TARGET_TAG https://github.com/CasperLabs/CasperLabs.git
+  git clone --single-branch --branch $TARGET_BRANCH https://github.com/hdac-io/CasperLabs.git
 fi
 
 cd CasperLabs
-git fetch origin refs/tags/$CASPERLABS_TARGET_TAG:refs/tags/$CASPERLABS_TARGET_TAG
-git checkout $CASPERLABS_TARGET_TAG
+git fetch origin $TARGET_BRANCH
+git reset --hard $COMMIT_HASH
 
 cd execution-engine
 make setup
@@ -25,10 +26,6 @@ declare -a TARGET_CONTRACTS=(
   "pos-install"
   "counter-call"
   "counter-define"
-  "standard-payment"
-  "transfer-to-account"
-  "bonding"
-  "unbonding"
 )
 
 declare -a WASM_FILES=(
@@ -36,14 +33,10 @@ declare -a WASM_FILES=(
   "pos_install.wasm"
   "counter_call.wasm"
   "counter_define.wasm"
-  "standard_payment.wasm"
-  "transfer_to_account.wasm"
-  "bonding.wasm"
-  "unbonding.wasm"
 )
 
 for pkg in "${TARGET_CONTRACTS[@]}"; do
-  make build-contract/$pkg
+  make build-contract-rs/$pkg
 done
 
 CONTRACT_DIR="$HOME/.nodef/contracts"

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/client"
 	"github.com/hdac-io/friday/codec"
@@ -86,18 +87,9 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("type must be one of wasm, name, uref, or hash")
 			}
 
-			var sessionAbi []byte
-			if args[2] == "" {
-				sessionAbi, err = cliutil.ProtobufSafeDecodeingHexString(args[2])
-				if err != nil {
-					return err
-				}
-			} else {
-				sessionArgs, err := util.JsonStringToDeployArgs(args[2])
-				if err != nil {
-					return err
-				}
-				sessionAbi, err = util.AbiDeployArgsTobytes(sessionArgs)
+			sessionArgs := []*consensus.Deploy_Arg{}
+			if args[2] != "" {
+				sessionArgs, err = util.JsonStringToDeployArgs(args[2])
 				if err != nil {
 					return err
 				}
@@ -119,7 +111,7 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				fromAddr,
 				sessionType,
 				sessionCode,
-				sessionAbi,
+				sessionArgs,
 				fee,
 				gasPrice,
 			)

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	"github.com/hdac-io/friday/client"
 	"github.com/hdac-io/friday/codec"
@@ -87,14 +86,6 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("type must be one of wasm, name, uref, or hash")
 			}
 
-			sessionArgs := []*consensus.Deploy_Arg{}
-			if args[2] != "" {
-				sessionArgs, err = util.JsonStringToDeployArgs(args[2])
-				if err != nil {
-					return err
-				}
-			}
-
 			fee, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				return err
@@ -111,7 +102,7 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 				fromAddr,
 				sessionType,
 				sessionCode,
-				sessionArgs,
+				args[2],
 				fee,
 				gasPrice,
 			)

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -1,6 +1,7 @@
 package executionlayer
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
@@ -52,12 +53,19 @@ func InitGenesis(
 		panic(errStr)
 	}
 
+	proxyContractHash := []byte{}
 	for _, namedKey := range res.GetAccount().GetNamedKeys() {
 		if namedKey.GetName() == types.ProxyContractName {
-			keeper.SetProxyContractHash(ctx, namedKey.GetKey().GetHash().GetHash())
+			proxyContractHash = namedKey.GetKey().GetHash().GetHash()
 			break
 		}
 	}
+
+	if len(proxyContractHash) != 32 {
+		panic(fmt.Sprintf("%s must exist. Check systemcontract.", types.ProxyContractName))
+	}
+
+	keeper.SetProxyContractHash(ctx, proxyContractHash)
 }
 
 // ExportGenesis : exports an executionlayer configuration for genesis

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -45,6 +45,19 @@ func InitGenesis(
 	candidateBlock.Hash = []byte(types.GenesisBlockHashKey)
 	candidateBlock.State = stateHash
 	candidateBlock.Bonds = bonds
+
+	systemAccount := make([]byte, 32)
+	res, errStr := grpc.Query(keeper.client, stateHash, "address", systemAccount, []string{}, genesisConfig.GetProtocolVersion())
+	if errStr != "" {
+		panic(errStr)
+	}
+
+	for _, namedKey := range res.GetAccount().GetNamedKeys() {
+		if namedKey.GetName() == types.ProxyContractName {
+			keeper.SetProxyContractHash(ctx, namedKey.GetKey().GetHash().GetHash())
+			break
+		}
+	}
 }
 
 // ExportGenesis : exports an executionlayer configuration for genesis

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -298,3 +298,17 @@ func (k ExecutionLayerKeeper) GetAllValidators(ctx sdk.Context) (validators []ty
 }
 
 // -----------------------------------------------------------------------------------------------------------
+
+// GetProxyContractHash retrieves proxy_contract_hash
+func (k ExecutionLayerKeeper) GetProxyContractHash(ctx sdk.Context) []byte {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	proxyContractHash := store.Get([]byte(types.ProxyContractHashKey))
+
+	return proxyContractHash
+}
+
+// SetProxyContractHash save proxy_contract_hash value.
+func (k ExecutionLayerKeeper) SetProxyContractHash(ctx sdk.Context, contractHash []byte) {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	store.Set([]byte(types.ProxyContractHashKey), contractHash)
+}

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc/transforms"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
@@ -101,7 +102,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterDefineWasm)),
-		[]byte{},
+		[]*consensus.Deploy_Arg{},
 		uint64(100000000),
 		uint64(10),
 	)
@@ -121,7 +122,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterCallWasm)),
-		[]byte{},
+		[]*consensus.Deploy_Arg{},
 		uint64(100000000),
 		uint64(10),
 	)
@@ -189,7 +190,7 @@ func TestTransfer(t *testing.T) {
 
 func TestMarsahlAndUnMarshal(t *testing.T) {
 	src := &transforms.TransformEntry{
-		Transform: &transforms.Transform{TransformInstance: &transforms.Transform_Write{Write: &transforms.TransformWrite{Value: &state.Value{Value: &state.Value_IntValue{IntValue: 1}}}}}}
+		Transform: &transforms.Transform{TransformInstance: &transforms.Transform_Write{Write: &transforms.TransformWrite{Value: &state.StoredValue{Variants: &state.StoredValue_ClValue{ClValue: &state.CLValue{ClType: &state.CLType{Variants: &state.CLType_SimpleType{SimpleType: state.CLType_BOOL}}, SerializedValue: []byte{1, 2, 3}}}}}}}}
 	bz, _ := proto.Marshal(src)
 
 	obj := &transforms.TransformEntry{}
@@ -263,4 +264,15 @@ func TestValidator(t *testing.T) {
 
 	validators := input.elk.GetAllValidators(input.ctx)
 	assert.Equal(t, 1, len(validators))
+}
+
+func TestProxyContractKeeper(t *testing.T) {
+	input := setupTestInput()
+
+	contractHash := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	input.elk.SetProxyContractHash(input.ctx, contractHash)
+
+	res := input.elk.GetProxyContractHash(input.ctx)
+
+	assert.Equal(t, contractHash, res)
 }

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/grpc"
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc/transforms"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
@@ -102,7 +101,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterDefineWasm)),
-		[]*consensus.Deploy_Arg{},
+		"",
 		uint64(100000000),
 		uint64(10),
 	)
@@ -122,7 +121,7 @@ func TestCreateBlock(t *testing.T) {
 		GenesisAccountAddress,
 		util.WASM,
 		util.LoadWasmFile(path.Join(contractPath, counterCallWasm)),
-		[]*consensus.Deploy_Arg{},
+		"",
 		uint64(100000000),
 		uint64(10),
 	)

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -122,12 +122,19 @@ func genesis(input testInput) []byte {
 		panic(errStr)
 	}
 
+	proxyContractHash := []byte{}
 	for _, namedKey := range res.GetAccount().GetNamedKeys() {
 		if namedKey.GetName() == types.ProxyContractName {
-			input.elk.SetProxyContractHash(input.ctx, namedKey.GetKey().GetHash().GetHash())
+			proxyContractHash = namedKey.GetKey().GetHash().GetHash()
 			break
 		}
 	}
+
+	if len(proxyContractHash) != 32 {
+		panic(fmt.Sprintf("%s must exist. Check systemcontract.", types.ProxyContractName))
+	}
+
+	input.elk.SetProxyContractHash(input.ctx, proxyContractHash)
 
 	return response.GetSuccess().PoststateHash
 }

--- a/x/executionlayer/types/key.go
+++ b/x/executionlayer/types/key.go
@@ -12,10 +12,11 @@ const (
 	HashMapStoreKey = ModuleName + "_hashmap"
 
 	// key value
-	GenesisBlockHashKey = "genesisblockhash"
-	GenesisConfigKey    = "genesisconf"
-	GenesisAccountKey   = "genesisaccount"
-	CandidateBlockKey   = "candidateblock"
+	GenesisBlockHashKey  = "genesisblockhash"
+	GenesisConfigKey     = "genesisconf"
+	GenesisAccountKey    = "genesisaccount"
+	CandidateBlockKey    = "candidateblock"
+	ProxyContractHashKey = "proxycontractkey"
 )
 
 var (

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/tendermint/crypto"
@@ -13,13 +14,13 @@ const RouterKey = ModuleName
 
 // MsgExecute for sending deploy to execution engine
 type MsgExecute struct {
-	ContractAddress string            `json:"contract_address"`
-	ExecAddress     sdk.AccAddress    `json:"exec_address"`
-	SessionType     util.ContractType `json:"session_type"`
-	SessionCode     []byte            `json:"session_code"`
-	SessionArgs     []byte            `json:"session_args"`
-	Fee             uint64            `json:"fee"`
-	GasPrice        uint64            `json:"gas_price"`
+	ContractAddress string                  `json:"contract_address"`
+	ExecAddress     sdk.AccAddress          `json:"exec_address"`
+	SessionType     util.ContractType       `json:"session_type"`
+	SessionCode     []byte                  `json:"session_code"`
+	SessionArgs     []*consensus.Deploy_Arg `json:"session_args"`
+	Fee             uint64                  `json:"fee"`
+	GasPrice        uint64                  `json:"gas_price"`
 }
 
 // NewMsgExecute is a constructor function for MsgSetName
@@ -27,7 +28,8 @@ func NewMsgExecute(
 	contractAddress string,
 	execAddress sdk.AccAddress,
 	sessionType util.ContractType,
-	sessionCode, sessionArgs []byte,
+	sessionCode []byte,
+	sessionArgs []*consensus.Deploy_Arg,
 	fee, gasPrice uint64,
 ) MsgExecute {
 	return MsgExecute{

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/tendermint/crypto"
@@ -14,13 +13,13 @@ const RouterKey = ModuleName
 
 // MsgExecute for sending deploy to execution engine
 type MsgExecute struct {
-	ContractAddress string                  `json:"contract_address"`
-	ExecAddress     sdk.AccAddress          `json:"exec_address"`
-	SessionType     util.ContractType       `json:"session_type"`
-	SessionCode     []byte                  `json:"session_code"`
-	SessionArgs     []*consensus.Deploy_Arg `json:"session_args"`
-	Fee             uint64                  `json:"fee"`
-	GasPrice        uint64                  `json:"gas_price"`
+	ContractAddress string            `json:"contract_address"`
+	ExecAddress     sdk.AccAddress    `json:"exec_address"`
+	SessionType     util.ContractType `json:"session_type"`
+	SessionCode     []byte            `json:"session_code"`
+	SessionArgs     string            `json:"session_args"`
+	Fee             uint64            `json:"fee"`
+	GasPrice        uint64            `json:"gas_price"`
 }
 
 // NewMsgExecute is a constructor function for MsgSetName
@@ -29,7 +28,7 @@ func NewMsgExecute(
 	execAddress sdk.AccAddress,
 	sessionType util.ContractType,
 	sessionCode []byte,
-	sessionArgs []*consensus.Deploy_Arg,
+	sessionArgs string,
 	fee, gasPrice uint64,
 ) MsgExecute {
 	return MsgExecute{

--- a/x/executionlayer/types/types.go
+++ b/x/executionlayer/types/types.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+const (
+	ProxyContractName  = "client_api_proxy"
+	TransferMethodName = "transfer_to_account"
+	PaymentMethodName  = "standard_payment"
+	BondMethodName     = "bond"
+	UnbondMethodName   = "unbond"
+)
+
 // UnitHashMap used to define Unit account structure
 type UnitHashMap struct {
 	EEState []byte `json:"ee_state"`

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -1,10 +1,11 @@
 package executionlayer
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	sdk "github.com/hdac-io/friday/types"
 	"github.com/hdac-io/friday/x/nickname"
 )
@@ -41,10 +42,20 @@ func toBytes(keyType string, key string,
 	return bytes, nil
 }
 
-func ProtobufSafeEncodeBytes(src []byte) []byte {
-	if bytes.Equal(src, []byte("empty")) {
-		src = []byte{}
+func DeployArgsToJsonString(args []*consensus.Deploy_Arg) (string, error) {
+	m := &jsonpb.Marshaler{}
+	str := "["
+	for idx, arg := range args {
+		if idx != 0 {
+			str += ","
+		}
+		s, err := m.MarshalToString(arg)
+		if err != nil {
+			return "", err
+		}
+		str += s
 	}
+	str += "]"
 
-	return src
+	return str, nil
 }


### PR DESCRIPTION
Content
--
- do not need to copy wasm anymore.
- follow up casperlabs v0.11.0

PS
--
- ~the end of https://github.com/hdac-io/casperlabs-ee-grpc-go-util/pull/12, will be change go.mod~