### PR TITLE
feat: support vote and some query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.4.2
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.4.2 h1:GsDOx9H2RdIa5R+2KZ8QEZiR2+E6ZjkcC3AOMhB+tmw=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.4.2/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0 h1:p1A2Ar99d0+d2/KQKFpLePU+O7u0OXTYCKPAE+CbyPA=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67 h1:OSzSGQymPfKubl5iOhVSoOI0vb5l2ToigNZF6F+jvCs=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1 h1:eO5Xe6twdvDYB9TjfCtnROqg+iQGSWbcyx4RhrvKF7w=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073 h1:+hUpDS2JmpZyY7SnIumano8EgWlykp4JbForu6slgrI=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67 h1:OSzSGQymPfKubl5iOhVSoOI0vb5l2ToigNZF6F+jvCs=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200409084219-4ee37d761c67/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0 h1:p1A2Ar99d0+d2/KQKFpLePU+O7u0OXTYCKPAE+CbyPA=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073 h1:+hUpDS2JmpZyY7SnIumano8EgWlykp4JbForu6slgrI=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1-0.20200408060335-bbfaa202f073/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/integration_tests/lib/cmd.py
+++ b/integration_tests/lib/cmd.py
@@ -336,11 +336,33 @@ def redelegate(passphrase: str, src_validator_address: str, dest_validator_addre
     client_home = os.path.join(os.environ["HOME"], client_home)
     return _tx_executor("clif hdac redelegate {} {} {} {} {} --from {} --node {} --home {}", passphrase, src_validator_address, dest_validator_address, amount, fee, gas_price, from_value, node, client_home)
 
+def vote(passphrase: str, hash: str, amount: str, fee: str, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac vote {} {} {} {} --from {} --node {} --home {}", passphrase, hash, amount, fee, gas_price, from_value, node, client_home)
+
+def unvote(passphrase: str, hash: str, amount: str, fee: str, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac unvote {} {} {} {} --from {} --node {} --home {}", passphrase, hash, amount, fee, gas_price, from_value, node, client_home)
+
 def get_balance(from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
     client_home = os.path.join(os.environ["HOME"], client_home)
     res = _process_executor("clif hdac getbalance --from {} --node {} --home {}", from_value, node, client_home, need_output=True)
     return res
 
+def get_validator(validator_address: str, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac validator {} --from {} --node {} --home {}", validator_address, from_value, node, client_home, need_output=True)
+    return res
+
+def get_delegator(validator_address: str, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac delegator {} --from {} --node {} --home {}", validator_address, from_value, node, client_home, need_output=True)
+    return res
+
+def get_voter(hash: str, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac voter {} --from {} --node {} --home {}", hash, from_value, node, client_home, need_output=True)
+    return res
 
 def create_validator(passphrase: str, from_value: str, pubkey: str, moniker: str, identity: str='""', website: str='""', details: str='""', node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
     client_home = os.path.join(os.environ["HOME"], client_home)

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -380,7 +380,7 @@ class TestSingleNode():
         is_ok = cmd.is_tx_ok(delegate_tx_hash)
         assert(is_ok == True)
 
-        res = cmd.get_delegator("", self.info_anna['address'])
+        res = cmd.get_delegator(self.info_elsa['address'], self.info_anna['address'])
         print("Output: ", res)
         assert(res[0]["amount"] == self.delegate_amount_bigsun) 
 
@@ -394,7 +394,7 @@ class TestSingleNode():
         is_ok = cmd.is_tx_ok(redelegate_tx_hash)
         assert(is_ok == True)
 
-        res = cmd.get_delegator("", self.info_olaf['address'])
+        res = cmd.get_delegator(self.info_olaf['address'], self.info_anna['address'])
         print("Output: ", res)
         assert(res[0]["amount"] == self.delegate_amount_bigsun) 
 

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -14,6 +14,8 @@ class TestSingleNode():
     chain_id = "testchain"
     moniker = "testnode"
 
+    system_contract = "0000000000000000000000000000000000000000000000000000000000000000"
+
     wallet_elsa = "elsa"
     wallet_anna = "anna"
     wallet_olaf = "olaf"
@@ -40,8 +42,14 @@ class TestSingleNode():
     bonding_gas = 50000000
 
     delegate_amount = "1"
-    delegate_fee = "0.002"
+    delegate_amount_bigsun = "1000000000000000000"
+    delegate_fee = "0.003"
     delegate_gas = 50000000
+
+    vote_amount = "1"
+    vote_amount_bigsun = "1000000000000000000"
+    vote_fee = "0.003"
+    vote_gas = 50000000
 
     transfer_amount = "1"
     transfer_fee = "0.001"
@@ -359,12 +367,12 @@ class TestSingleNode():
         assert(is_ok == True)
         print("======================End test05_custom_contract_execution======================")
 
-    def test06_simple_delegate_redelegate_and_undlegate(self):
-        print("======================Start test06_simple_delegate_and_undlegate======================")
+    def test06_simple_delegate_redelegate_and_undelegate(self):
+        print("======================Start test06_simple_delegate_and_undelegate======================")
 
         print("Delegate token")
         delegate_tx_hash = cmd.delegate(self.wallet_password, self.info_elsa['address'], self.delegate_amount, self.delegate_fee, self.delegate_gas, self.wallet_anna)
-        print("Tx sent. Waiting for validation")
+        print("Tx sent. Waiting for delegate")
 
         time.sleep(self.tx_block_time * 3 + 1)
 
@@ -372,9 +380,13 @@ class TestSingleNode():
         is_ok = cmd.is_tx_ok(delegate_tx_hash)
         assert(is_ok == True)
 
+        res = cmd.get_delegator("", self.info_anna['address'])
+        print("Output: ", res)
+        assert(res[0]["amount"] == self.delegate_amount_bigsun) 
+
         print("Redelegate token")
         redelegate_tx_hash = cmd.redelegate(self.wallet_password, self.info_elsa['address'], self.info_olaf['address'], self.delegate_amount, self.delegate_fee, self.delegate_gas, self.wallet_anna)
-        print("Tx sent. Waiting for validation")
+        print("Tx sent. Waiting for redelegate")
 
         time.sleep(self.tx_block_time * 3 + 1)
 
@@ -382,9 +394,13 @@ class TestSingleNode():
         is_ok = cmd.is_tx_ok(redelegate_tx_hash)
         assert(is_ok == True)
 
+        res = cmd.get_delegator("", self.info_olaf['address'])
+        print("Output: ", res)
+        assert(res[0]["amount"] == self.delegate_amount_bigsun) 
+
         print("Undelegate token")
         undelegate_tx_hash = cmd.undelegate(self.wallet_password, self.info_olaf['address'], self.delegate_amount, self.delegate_fee, self.delegate_gas, self.wallet_anna)
-        print("Tx sent. Waiting for validation")
+        print("Tx sent. Waiting for undelegate")
 
         time.sleep(self.tx_block_time * 3 + 1)
 
@@ -392,4 +408,33 @@ class TestSingleNode():
         is_ok = cmd.is_tx_ok(undelegate_tx_hash)
         assert(is_ok == True)
 
-        print("======================Done test06_simple_delegate_and_undlegate======================")
+        print("======================Done test06_simple_delegate_and_undelegate======================")
+
+    def test07_simple_vote_and_unvote(self):
+        print("======================Start test07_simple_vote_and_unvote======================")
+
+        print("Vote token")
+        delegate_tx_hash = cmd.vote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
+        print("Tx sent. Waiting for vote")
+
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        print("Check whether tx is ok or not")
+        is_ok = cmd.is_tx_ok(delegate_tx_hash)
+        assert(is_ok == True)
+
+        res = cmd.get_voter(self.system_contract, self.info_anna['address'])
+        print("Output: ", res)
+        assert(res[0]["amount"] == self.vote_amount_bigsun) 
+
+        print("Unvote token")
+        redelegate_tx_hash = cmd.unvote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
+        print("Tx sent. Waiting for unvote")
+
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        print("Check whether tx is ok or not")
+        is_ok = cmd.is_tx_ok(redelegate_tx_hash)
+        assert(is_ok == True)
+
+        print("======================Done test07_simple_vote_and_unvote======================")

--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -8,7 +8,7 @@ if [ ${PWD##*/} != "friday" ]; then
 fi
 
 TARGET_BRANCH="master"
-COMMIT_HASH="4937e7b35c3ffc575666afe3206cc7a037e39753"
+COMMIT_HASH="16e1b0378a03ee8db0e35e57709a892f15113e00"
 if [ ! -d "CasperLabs/.git" ]; then
   git clone --single-branch --branch $TARGET_BRANCH https://github.com/hdac-io/CasperLabs.git
 fi

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -35,4 +35,5 @@ type (
 	QueryExecutionLayerDetail = types.QueryExecutionLayerDetail
 	QueryGetBalanceDetail     = types.QueryGetBalanceDetail
 	QueryValidatorParams      = types.QueryValidatorParams
+	QueryDelegatorParams      = types.QueryDelegatorParams
 )

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -30,11 +30,9 @@ type (
 	MsgUnBond                 = types.MsgUnBond
 	MsgCreateValidator        = types.MsgCreateValidator
 	MsgEditValidator          = types.MsgEditValidator
-	QueryExecutionLayer       = types.QueryExecutionLayer
 	UnitHashMap               = types.UnitHashMap
 	QueryExecutionLayerResp   = types.QueryExecutionLayerResp
 	QueryExecutionLayerDetail = types.QueryExecutionLayerDetail
-	QueryGetBalance           = types.QueryGetBalance
 	QueryGetBalanceDetail     = types.QueryGetBalanceDetail
 	QueryValidatorParams      = types.QueryValidatorParams
 )

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -36,4 +36,5 @@ type (
 	QueryGetBalanceDetail     = types.QueryGetBalanceDetail
 	QueryValidatorParams      = types.QueryValidatorParams
 	QueryDelegatorParams      = types.QueryDelegatorParams
+	QueryVoterParams          = types.QueryVoterParams
 )

--- a/x/executionlayer/client/cli/query.go
+++ b/x/executionlayer/client/cli/query.go
@@ -129,16 +129,30 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 // GetCmdQueryValidator implements the validator query command.
 func GetCmdQueryValidator(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "validator --from <from>",
+		Use:   "validator [--from <from>]",
 		Short: "Query a validator",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			valueFromFromFlag := viper.GetString(client.FlagFrom)
-			addr, err := cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
-			if err != nil {
-				return err
+			var addr sdk.AccAddress
+			var err error
+			if valueFromFromFlag != "" {
+				addr, err = cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
+				if err != nil {
+					kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+					if err != nil {
+						return err
+					}
+
+					keyInfo, err := kb.Get(valueFromFromFlag)
+					if err != nil {
+						return err
+					}
+
+					addr = keyInfo.GetAddress()
+				}
 			}
 
 			if addr.Empty() {
@@ -190,9 +204,23 @@ func GetCmdQueryDelegator(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			valueFromFromFlag := viper.GetString(client.FlagFrom)
-			addr, err := cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
-			if err != nil {
-				return err
+			var addr sdk.AccAddress
+			var err error
+			if valueFromFromFlag != "" {
+				addr, err = cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
+				if err != nil {
+					kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+					if err != nil {
+						return err
+					}
+
+					keyInfo, err := kb.Get(valueFromFromFlag)
+					if err != nil {
+						return err
+					}
+
+					addr = keyInfo.GetAddress()
+				}
 			}
 
 			var validator sdk.AccAddress
@@ -253,9 +281,23 @@ func GetCmdQueryVoter(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			valueFromFromFlag := viper.GetString(client.FlagFrom)
-			addr, err := cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
-			if err != nil {
-				return err
+			var addr sdk.AccAddress
+			var err error
+			if valueFromFromFlag != "" {
+				addr, err = cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
+				if err != nil {
+					kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+					if err != nil {
+						return err
+					}
+
+					keyInfo, err := kb.Get(valueFromFromFlag)
+					if err != nil {
+						return err
+					}
+
+					addr = keyInfo.GetAddress()
+				}
 			}
 
 			var hash []byte

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -30,6 +30,7 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		// Query
 		GetCmdQueryBalance(cdc),
 		GetCmdQueryValidator(cdc),
+		GetCmdQueryDelegator(cdc),
 	)...)
 	return hdacCustomTxCmd
 }

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -26,11 +26,14 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		GetCmdRedelegate(cdc),
 		GetCmdCreateValidator(cdc),
 		GetCmdEditValidator(cdc),
+		GetCmdVote(cdc),
+		GetCmdUnvote(cdc),
 
 		// Query
 		GetCmdQueryBalance(cdc),
 		GetCmdQueryValidator(cdc),
 		GetCmdQueryDelegator(cdc),
+		GetCmdQueryVoter(cdc),
 	)...)
 	return hdacCustomTxCmd
 }

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -441,6 +442,124 @@ func GetCmdRedelegate(cdc *codec.Codec) *cobra.Command {
 			// build and sign the transaction, then broadcast to Tendermint
 			// TODO: Currently implementation of contract address is dummy
 			msg := types.NewMsgRedelegate("dummyAddress", addr, srcValAddress, destValAddress, string(amount), string(fee), gasPrice)
+			txBldr = txBldr.WithGas(gasPrice)
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+
+	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
+
+	return cmd
+}
+
+func GetCmdVote(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vote <hash> <amount> <fee> <gas-price> --from <from>",
+		Short: "Vote token",
+		Long:  "Vote token for converts tokens as a freedom",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+			if err != nil {
+				return err
+			}
+
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
+			}
+
+			hash, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+
+			}
+
+			amount, err := cliutil.ToBigsun(cliutil.Hdac(args[1]))
+			if err != nil {
+				return err
+			}
+
+			fee, err := cliutil.ToBigsun(cliutil.Hdac(args[2]))
+			if err != nil {
+				return err
+			}
+
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
+			addr := keyInfo.GetAddress()
+
+			gasPrice, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			// build and sign the transaction, then broadcast to Tendermint
+			// TODO: Currently implementation of contract address is dummy
+			msg := types.NewMsgVote("dummyAddress", addr, hash, string(amount), string(fee), gasPrice)
+			txBldr = txBldr.WithGas(gasPrice)
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+
+	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
+
+	return cmd
+}
+
+func GetCmdUnvote(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unvote <hash> <amount> <fee> <gas-price> --from <from>",
+		Short: "Unvote token",
+		Long:  "Unvote token for converts tokens as a freedom",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+			if err != nil {
+				return err
+			}
+
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			keyInfo, err := cliutil.GetLocalWalletInfo(valueFromFromFlag, kb, cdc, cliCtx)
+			if err != nil {
+				return err
+			}
+
+			hash, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+
+			}
+
+			amount, err := cliutil.ToBigsun(cliutil.Hdac(args[1]))
+			if err != nil {
+				return err
+			}
+
+			fee, err := cliutil.ToBigsun(cliutil.Hdac(args[2]))
+			if err != nil {
+				return err
+			}
+
+			cliCtx = cliCtx.WithFromAddress(keyInfo.GetAddress()).WithFromName(keyInfo.GetName())
+			addr := keyInfo.GetAddress()
+
+			gasPrice, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			// build and sign the transaction, then broadcast to Tendermint
+			// TODO: Currently implementation of contract address is dummy
+			msg := types.NewMsgUnvote("dummyAddress", addr, hash, string(amount), string(fee), gasPrice)
 			txBldr = txBldr.WithGas(gasPrice)
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},

--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -294,25 +293,14 @@ func getBalanceQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *htt
 		return nil, err
 	}
 
-	var bz []byte
-
-	if blockHashStr == "" {
-		queryData := types.QueryGetBalance{
-			Address: addr,
-		}
-		bz = cliCtx.Codec.MustMarshalJSON(queryData)
-		//return bz, nil
-	} else {
-		blockHash, err := hex.DecodeString(blockHashStr)
-		if err != nil {
-			return nil, err
-		}
-		queryData := types.QueryGetBalanceDetail{
-			Address:   addr,
-			StateHash: blockHash,
-		}
-		bz = cliCtx.Codec.MustMarshalJSON(queryData)
+	if err != nil {
+		return nil, err
 	}
+	queryData := types.QueryGetBalanceDetail{
+		Address:   addr,
+		BlockHash: blockHashStr,
+	}
+	bz := cliCtx.Codec.MustMarshalJSON(queryData)
 
 	return bz, nil
 }

--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -407,3 +407,31 @@ func getValidatorQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *h
 
 	return bz, nil
 }
+
+func getDelegatorQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *http.Request) ([]byte, error) {
+	vars := r.URL.Query()
+	validatorAddressStr := vars.Get("validator")
+	validatorAddress, err := cliutil.GetAddress(cliCtx.Codec, cliCtx, validatorAddressStr)
+	if err != nil {
+		return nil, err
+	}
+
+	delegatorAddressStr := vars.Get("delegator")
+	delegatorAddress, err := cliutil.GetAddress(cliCtx.Codec, cliCtx, delegatorAddressStr)
+	if err != nil {
+		return nil, err
+	}
+
+	if validatorAddress.Empty() && delegatorAddress.Empty() {
+		return nil, fmt.Errorf("Requires validator or delegate address.")
+	}
+
+	queryData := types.QueryDelegatorParams{
+		ValidatorAddr: validatorAddress,
+		DelegatorAddr: delegatorAddress,
+	}
+
+	bz := cliCtx.Codec.MustMarshalJSON(queryData)
+
+	return bz, nil
+}

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -166,6 +167,52 @@ func TestRESTRedelegate(t *testing.T) {
 	require.NotNil(t, msgs)
 }
 
+func TestRESTVote(t *testing.T) {
+	_, _, writer, clictx, basereq := prepare()
+	hash := hex.EncodeToString(types.SYSTEM_ACCOUNT)
+
+	// Body
+	delegateReq := voteReq{
+		BaseReq: basereq,
+		Hash:    hash,
+		Amount:  "100000000",
+		Fee:     "10000000",
+	}
+
+	// http.request
+	body := clictx.Codec.MustMarshalJSON(delegateReq)
+	req := mustNewRequest(t, "POST", fmt.Sprintf("/%s/vote", types.ModuleName), bytes.NewReader(body))
+
+	outputBasereq, msgs, err := voteUnvoteMsgCreator(true, writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputBasereq, basereq)
+	require.NotNil(t, msgs)
+}
+
+func TestRESTUnvote(t *testing.T) {
+	_, _, writer, clictx, basereq := prepare()
+	hash := hex.EncodeToString(types.SYSTEM_ACCOUNT)
+
+	// Body
+	delegateReq := voteReq{
+		BaseReq: basereq,
+		Hash:    hash,
+		Amount:  "100000000",
+		Fee:     "10000000",
+	}
+
+	// http.request
+	body := clictx.Codec.MustMarshalJSON(delegateReq)
+	req := mustNewRequest(t, "POST", fmt.Sprintf("/%s/unvote", types.ModuleName), bytes.NewReader(body))
+
+	outputBasereq, msgs, err := voteUnvoteMsgCreator(false, writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputBasereq, basereq)
+	require.NotNil(t, msgs)
+}
+
 func TestRESTBalance(t *testing.T) {
 	fromAddr, _, writer, clictx, _ := prepare()
 
@@ -191,6 +238,68 @@ func TestRESTGetValidators(t *testing.T) {
 
 	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/validator", types.ModuleName), nil)
 	res, err := getValidatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetDelegatorFromValidator(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/delegator?validator=%s", types.ModuleName, fromAddr), nil)
+	res, err := getDelegatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetDelegatorFromDelegator(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/delegator?delegator=%s", types.ModuleName, fromAddr), nil)
+	res, err := getDelegatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetDelegatorFromAll(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/delegator?validator=%s&delegator=%s", types.ModuleName, fromAddr, fromAddr), nil)
+	res, err := getDelegatorQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetVoterFromAddress(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/voter?address=%s", types.ModuleName, fromAddr), nil)
+	res, err := getVoterQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetVoterFromDapp(t *testing.T) {
+	_, _, writer, clictx, _ := prepare()
+	hash := hex.EncodeToString(types.SYSTEM_ACCOUNT)
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/voter?hash=%s", types.ModuleName, hash), nil)
+	res, err := getVoterQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetVoterFromAll(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+	hash := hex.EncodeToString(types.SYSTEM_ACCOUNT)
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/voter?hash=%s&address=%s", types.ModuleName, hash, fromAddr), nil)
+	res, err := getVoterQuerying(writer, clictx, req)
 
 	require.NoError(t, err)
 	require.NotNil(t, res)

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -25,6 +25,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/delegate", hdacSpecific), delegateHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/undelegate", hdacSpecific), undelegateHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/redelegate", hdacSpecific), redelegateHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/delegator", hdacSpecific), getDelegatorHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/balance", hdacSpecific), getBalanceHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), getValidatorHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), createValidatorHandler(cliCtx)).Methods("POST")
@@ -155,6 +156,24 @@ func getValidatorHandler(cliCtx context.CLIContext, storeName string) http.Handl
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		rest.PostProcessResponseBare(w, cliCtx, res)
+	}
+}
+
+func getDelegatorHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bz, err := getDelegatorQuerying(w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/querydelegator", types.ModuleName), bz)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
 		rest.PostProcessResponseBare(w, cliCtx, res)
 	}
 }

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -25,6 +25,9 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/delegate", hdacSpecific), delegateHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/undelegate", hdacSpecific), undelegateHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/redelegate", hdacSpecific), redelegateHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/vote", hdacSpecific), voteHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/unvote", hdacSpecific), unvoteHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/voter", hdacSpecific), getVoterHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/delegator", hdacSpecific), getDelegatorHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/balance", hdacSpecific), getBalanceHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/validators", hdacSpecific), getValidatorHandler(cliCtx, storeName)).Methods("GET")
@@ -90,6 +93,28 @@ func undelegateHandler(cliCtx context.CLIContext) http.HandlerFunc {
 func redelegateHandler(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		baseReq, msgs, err := redelegateMsgCreator(w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, msgs)
+	}
+}
+
+func voteHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		baseReq, msgs, err := voteUnvoteMsgCreator(true, w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, msgs)
+	}
+}
+
+func unvoteHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		baseReq, msgs, err := voteUnvoteMsgCreator(false, w, cliCtx, r)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -169,6 +194,24 @@ func getDelegatorHandler(cliCtx context.CLIContext, storeName string) http.Handl
 		}
 
 		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/querydelegator", types.ModuleName), bz)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		rest.PostProcessResponseBare(w, cliCtx, res)
+	}
+}
+
+func getVoterHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bz, err := getVoterQuerying(w, cliCtx, r)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryvoter", types.ModuleName), bz)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -284,10 +284,8 @@ func handlerMsgRedelegate(ctx sdk.Context, k ExecutionLayerKeeper, msg types.Msg
 					BytesValue: msg.DestValAddress.ToEEAddress()}}},
 		&consensus.Deploy_Arg{
 			Value: &consensus.Deploy_Arg_Value{
-				Value: &consensus.Deploy_Arg_Value_OptionalValue{
-					OptionalValue: &consensus.Deploy_Arg_Value{
-						Value: &consensus.Deploy_Arg_Value_BigInt{
-							BigInt: &state.BigInt{Value: msg.Amount, BitWidth: 512}}}}}}}
+				Value: &consensus.Deploy_Arg_Value_BigInt{
+					BigInt: &state.BigInt{Value: msg.Amount, BitWidth: 512}}}}}
 
 	sessionArgsStr, err := DeployArgsToJsonString(sessionArgs)
 	if err != nil {

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -118,6 +118,13 @@ func queryValidator(ctx sdk.Context, req abci.RequestQuery, keeper ExecutionLaye
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, err.Error())
 	}
 
+	storedValue, err := getQueryResult(ctx, keeper, "", types.ADDRESS, types.SYSTEM, types.PosContractName)
+	if err != nil {
+		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", err.Error())
+	}
+
+	validator.Stake = storedValue.Contract.NamedKeys.GetValidatorStake(param.ValidatorAddr.ToEEAddress())
+
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/x/executionlayer/types/codec.go
+++ b/x/executionlayer/types/codec.go
@@ -23,4 +23,6 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgDelegate{}, "executionengine/Delegate", nil)
 	cdc.RegisterConcrete(MsgUndelegate{}, "executionengine/Undelegate", nil)
 	cdc.RegisterConcrete(MsgRedelegate{}, "executionengine/Redelegate", nil)
+	cdc.RegisterConcrete(MsgVote{}, "executionengine/Vote", nil)
+	cdc.RegisterConcrete(MsgUnvote{}, "executionengine/Unvote", nil)
 }

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -499,3 +499,113 @@ func (msg MsgRedelegate) GetSignBytes() []byte {
 func (msg MsgRedelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.FromAddress}
 }
+
+//______________________________________________________________________
+type MsgVote struct {
+	ContractAddress string         `json:"contract_address" yaml:"contract_address"`
+	FromAddress     sdk.AccAddress `json:"from_address" yaml:"from_address"`
+	Hash            []byte         `json:"hash" yaml:"hash"`
+	Amount          string         `json:"amount" yaml:"amount"`
+	Fee             string         `json:"fee" yaml:"fee"`
+	GasPrice        uint64         `json:"gas_price" yaml:"gas_price"`
+}
+
+// NewMsgVote is a constructor function for MsgSetName
+func NewMsgVote(
+	tokenContractAddress string,
+	fromAddress sdk.AccAddress,
+	hash []byte,
+	amount, fee string,
+	gasPrice uint64,
+) MsgVote {
+	return MsgVote{
+		ContractAddress: tokenContractAddress,
+		FromAddress:     fromAddress,
+		Hash:            hash,
+		Amount:          amount,
+		Fee:             fee,
+		GasPrice:        gasPrice,
+	}
+}
+
+// Route should return the name of the module
+func (msg MsgVote) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgVote) Type() string { return "executionengine" }
+
+// ValidateBasic runs stateless checks on the message
+func (msg MsgVote) ValidateBasic() sdk.Error {
+	if msg.FromAddress.Equals(sdk.AccAddress("")) {
+		return sdk.ErrUnknownRequest("Address cannot be empty")
+	}
+	if len(msg.Hash) != 32 {
+		return sdk.ErrUnknownRequest("Hash must be 32 bytes")
+	}
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgVote) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgVote) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.FromAddress}
+}
+
+//______________________________________________________________________
+type MsgUnvote struct {
+	ContractAddress string         `json:"contract_address" yaml:"contract_address"`
+	FromAddress     sdk.AccAddress `json:"from_address" yaml:"from_address"`
+	Hash            []byte         `json:"hash" yaml:"hash"`
+	Amount          string         `json:"amount" yaml:"amount"`
+	Fee             string         `json:"fee" yaml:"fee"`
+	GasPrice        uint64         `json:"gas_price" yaml:"gas_price"`
+}
+
+// NewMsgUnvote is a constructor function for MsgSetName
+func NewMsgUnvote(
+	tokenContractAddress string,
+	fromAddress sdk.AccAddress,
+	hash []byte,
+	amount, fee string,
+	gasPrice uint64,
+) MsgUnvote {
+	return MsgUnvote{
+		ContractAddress: tokenContractAddress,
+		FromAddress:     fromAddress,
+		Hash:            hash,
+		Amount:          amount,
+		Fee:             fee,
+		GasPrice:        gasPrice,
+	}
+}
+
+// Route should return the name of the module
+func (msg MsgUnvote) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgUnvote) Type() string { return "executionengine" }
+
+// ValidateBasic runs stateless checks on the message
+func (msg MsgUnvote) ValidateBasic() sdk.Error {
+	if msg.FromAddress.Equals(sdk.AccAddress("")) {
+		return sdk.ErrUnknownRequest("Address cannot be empty")
+	}
+	if len(msg.Hash) != 32 {
+		return sdk.ErrUnknownRequest("Hash must be 32 bytes")
+	}
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgUnvote) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgUnvote) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.FromAddress}
+}

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -74,3 +74,17 @@ func NewQueryDelegatorParams(delegaatorAddr sdk.AccAddress, validatorAddr sdk.Ac
 		ValidatorAddr: validatorAddr,
 	}
 }
+
+// defines the params for the following queries:
+// - 'custom/%s/voter'
+type QueryVoterParams struct {
+	Address sdk.AccAddress `json:"address"`
+	Hash    []byte         `json:"hash"`
+}
+
+func NewQueryVoterParams(address sdk.AccAddress, hash []byte) QueryVoterParams {
+	return QueryVoterParams{
+		Address: address,
+		Hash:    hash,
+	}
+}

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -52,11 +52,25 @@ func (q QueryExecutionLayerResp) String() string {
 // defines the params for the following queries:
 // - 'custom/%s/validator'
 type QueryValidatorParams struct {
-	ValidatorAddr sdk.AccAddress
+	ValidatorAddr sdk.AccAddress `json:"validator_address"`
 }
 
 func NewQueryValidatorParams(validatorAddr sdk.AccAddress) QueryValidatorParams {
 	return QueryValidatorParams{
+		ValidatorAddr: validatorAddr,
+	}
+}
+
+// defines the params for the following queries:
+// - 'custom/%s/delegator'
+type QueryDelegatorParams struct {
+	DelegatorAddr sdk.AccAddress `json:"delegator_address"`
+	ValidatorAddr sdk.AccAddress `json:"validator_address"`
+}
+
+func NewQueryDelegatorParams(delegaatorAddr sdk.AccAddress, validatorAddr sdk.AccAddress) QueryDelegatorParams {
+	return QueryDelegatorParams{
+		DelegatorAddr: delegaatorAddr,
 		ValidatorAddr: validatorAddr,
 	}
 }

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -6,9 +6,18 @@ import (
 	sdk "github.com/hdac-io/friday/types"
 )
 
+const (
+	ADDRESS = "address"
+	UREF    = "uref"
+	HASH    = "hash"
+	LOCAL   = "local"
+
+	SYSTEM = "system"
+)
+
 // QueryExecutionLayerDetail payload for a EE query
 type QueryExecutionLayerDetail struct {
-	StateHash []byte `json:"state_hash"`
+	BlockHash string `json:"state_hash"`
 	KeyType   string `json:"key_type"`
 	KeyData   string `json:"key_data"`
 	Path      string `json:"path"`
@@ -16,40 +25,18 @@ type QueryExecutionLayerDetail struct {
 
 // implement fmt.Stringer
 func (q QueryExecutionLayerDetail) String() string {
-	return fmt.Sprintf("State: %s\nKey type: %s\nKey data: %s\nPath: %s", q.StateHash, q.KeyType, q.KeyData, q.Path)
-}
-
-// QueryExecutionLayer payload for a EE query
-type QueryExecutionLayer struct {
-	KeyType string `json:"key_type"`
-	KeyData string `json:"key_data"`
-	Path    string `json:"path"`
-}
-
-// implement fmt.Stringer
-func (q QueryExecutionLayer) String() string {
-	return fmt.Sprintf("Key type: %s\nKey data: %s\nPath: %s", q.KeyType, q.KeyData, q.Path)
+	return fmt.Sprintf("Block Hash: %s\nKey type: %s\nKey data: %s\nPath: %s", q.BlockHash, q.KeyType, q.KeyData, q.Path)
 }
 
 // QueryGetBalanceDetail payload for balance query
 type QueryGetBalanceDetail struct {
-	StateHash []byte
-	Address   sdk.AccAddress
+	BlockHash string         `json:"state_hash"`
+	Address   sdk.AccAddress `json:"address"`
 }
 
 // implement fmt.Stringer
 func (q QueryGetBalanceDetail) String() string {
-	return fmt.Sprintf("State: %s\nQuery public key or readable name: %s", q.StateHash, q.Address)
-}
-
-// QueryGetBalance payload for balance query in the latest data
-type QueryGetBalance struct {
-	Address sdk.AccAddress
-}
-
-// implement fmt.Stringer
-func (q QueryGetBalance) String() string {
-	return fmt.Sprintf("Query public key or readable name: %s", q.Address)
+	return fmt.Sprintf("State: %s\nQuery public key or readable name: %s", q.BlockHash, q.Address)
 }
 
 // QueryExecutionLayerResp is used for response of EE query

--- a/x/executionlayer/types/types.go
+++ b/x/executionlayer/types/types.go
@@ -21,6 +21,8 @@ const (
 	DelegateMethodName   = "delegate"
 	UndelegateMethodName = "undelegate"
 	RedelegateMethodName = "redelegate"
+	VoteMethodName       = "vote"
+	UnvoteMethodName     = "unvote"
 )
 
 // UnitHashMap used to define Unit account structure

--- a/x/executionlayer/types/types.go
+++ b/x/executionlayer/types/types.go
@@ -5,7 +5,14 @@ import (
 	"strings"
 )
 
+var (
+	SYSTEM_ACCOUNT = make([]byte, 32)
+)
+
 const (
+	MintContractName = "mint"
+	PosContractName  = "pos"
+
 	ProxyContractName    = "client_api_proxy"
 	TransferMethodName   = "transfer_to_account"
 	PaymentMethodName    = "standard_payment"

--- a/x/executionlayer/types/validator.go
+++ b/x/executionlayer/types/validator.go
@@ -228,7 +228,7 @@ func UnmarshalDelegator(cdc *codec.Codec, value []byte) (delegator Delegator, er
 
 // String returns a human readable string representation of a validator.
 func (d Delegator) String() string {
-	return fmt.Sprintf(`Validator
+	return fmt.Sprintf(`Deligator
   Address:           %s
   Amount:			 %s`, d.Address, d.Amount)
 }
@@ -237,6 +237,56 @@ func (d Delegator) String() string {
 type Delegators []Delegator
 
 func (d Delegators) String() (out string) {
+	for _, val := range d {
+		out += val.String() + "\n"
+	}
+	return strings.TrimSpace(out)
+}
+
+type Voter struct {
+	Address []byte `json:"address" yaml:"address"`
+	Amount  string `json:"amount" yaml:"amount"`
+}
+
+// NewVoter - initialize a new voter
+func NewVoter(address sdk.EEAddress, amount string) Voter {
+	return Voter{
+		Address: address,
+		Amount:  amount,
+	}
+}
+
+// return the voter
+func MustMarshalVoter(cdc *codec.Codec, voter Voter) []byte {
+	return cdc.MustMarshalBinaryLengthPrefixed(voter)
+}
+
+// unmarshal a delegator from a store value
+func MustUnmarshalVoter(cdc *codec.Codec, value []byte) Voter {
+	voter, err := UnmarshalVoter(cdc, value)
+	if err != nil {
+		panic(err)
+	}
+	return voter
+}
+
+// unmarshal a voter from a store value
+func UnmarshalVoter(cdc *codec.Codec, value []byte) (voter Voter, err error) {
+	err = cdc.UnmarshalBinaryLengthPrefixed(value, &voter)
+	return voter, err
+}
+
+// String returns a human readable string representation of a validator.
+func (d Voter) String() string {
+	return fmt.Sprintf(`Voters
+  Address:           %s
+  Amount:			 %s`, d.Address, d.Amount)
+}
+
+// Voters is a collection of Delegator
+type Voters []Voter
+
+func (d Voters) String() (out string) {
 	for _, val := range d {
 		out += val.String() + "\n"
 	}

--- a/x/executionlayer/types/validator.go
+++ b/x/executionlayer/types/validator.go
@@ -192,3 +192,53 @@ func (v Validators) String() (out string) {
 	}
 	return strings.TrimSpace(out)
 }
+
+type Delegator struct {
+	Address sdk.AccAddress `json:"address" yaml:"address"`
+	Amount  string         `json:"amount" yaml:"amount"`
+}
+
+// NewDelegator - initialize a new delegator
+func NewDelegator(address sdk.AccAddress, amount string) Delegator {
+	return Delegator{
+		Address: address,
+		Amount:  amount,
+	}
+}
+
+// return the delegate
+func MustMarshalDelegator(cdc *codec.Codec, delegator Delegator) []byte {
+	return cdc.MustMarshalBinaryLengthPrefixed(delegator)
+}
+
+// unmarshal a delegator from a store value
+func MustUnmarshalDelegator(cdc *codec.Codec, value []byte) Delegator {
+	delegator, err := UnmarshalDelegator(cdc, value)
+	if err != nil {
+		panic(err)
+	}
+	return delegator
+}
+
+// unmarshal a delegator from a store value
+func UnmarshalDelegator(cdc *codec.Codec, value []byte) (delegator Delegator, err error) {
+	err = cdc.UnmarshalBinaryLengthPrefixed(value, &delegator)
+	return delegator, err
+}
+
+// String returns a human readable string representation of a validator.
+func (d Delegator) String() string {
+	return fmt.Sprintf(`Validator
+  Address:           %s
+  Amount:			 %s`, d.Address, d.Amount)
+}
+
+// Delegators is a collection of Delegator
+type Delegators []Delegator
+
+func (d Delegators) String() (out string) {
+	for _, val := range d {
+		out += val.String() + "\n"
+	}
+	return strings.TrimSpace(out)
+}

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
 	sdk "github.com/hdac-io/friday/types"
+	"github.com/hdac-io/friday/x/executionlayer/types"
 	"github.com/hdac-io/friday/x/nickname"
 )
 
@@ -17,10 +18,10 @@ func toBytes(keyType string, key string,
 	var err error
 
 	switch keyType {
-	case "address":
+	case types.ADDRESS:
 		// we have special key for system account
-		if key == "system" {
-			bytes = make([]byte, 32)
+		if key == types.SYSTEM {
+			bytes = types.SYSTEM_ACCOUNT
 			break
 		}
 
@@ -37,7 +38,7 @@ func toBytes(keyType string, key string,
 		}
 		bytes = addr.ToEEAddress().Bytes()
 
-	case "uref", "local", "hash":
+	case types.UREF, types.LOCAL, types.HASH:
 		bytes, err = hex.DecodeString(key)
 
 	default:


### PR DESCRIPTION
Content
--
- refactoring query
- delegate query(cli, rest)
- vote
- about integration code

Example
--
- delegate query cli
```
$ clif hdac delegator [<vaidator-address>] [--from <from>]

// The delegate info of a specific validator
$ clif hdac delegator 'fridayxxxxxxxxxxxxx'

// Quantity of each stake in a specific delegator
$ clif hdac delegator --from 'fridayxxxxxxxxxxxxx'

// Both (self delegate or The delegate quantity of a specific validator)
$ clif hdac delegator 'fridayxxxxxxxxxxxxx' --from 'fridayxxxxxxxxxxxxx'
```
- delegate query rest
```
// The delegate info of a specific validator
$ http://localhost:1317/hdac/delegator?delegator=fridayxxxxxxxxxxxxx

// Quantity of each stake in a specific delegator
$ http://localhost:1317/hdac/delegator?validator=fridayxxxxxxxxxxxxx

// Both (self delegate or The delegate quantity of a specific validator)
$ http://localhost:1317/hdac/delegator?delegator=fridayxxxxxxxxxxxxx&validator=fridayxxxxxxxxxxxxx
```
- vote cli
```
$ clif hdac vote <hash> <amount> <fee> <gas-price> --from <from>

$ clif hdac vote 0000000000000000000000000000000000000000000000000000000000000000 1 0.00
2 30000000 --from fridayxxxxxxxxxxxxx
```
- unvote cli
```
$ clif hdac unvote <hash> <amount> <fee> <gas-price> --from <from>

$ clif hdac unvote 0000000000000000000000000000000000000000000000000000000000000000 1 0.00
2 30000000 --from fridayxxxxxxxxxxxxx
```
- vote query cli
```
$ clif hdac voter [<hash>] [--from <from>]

// The vote info of a specific dapp
$ clif hdac voter 0000000000000000000000000000000000000000000000000000000000000000

// Quantity of each vote in a specific voter
$ clif hdac voter --from fridayxxxxxxxxxxxxx

// Both
$ clif hdac voter 0000000000000000000000000000000000000000000000000000000000000000 --from fridayxxxxxxxxxxxxx
```
- vote query rest
```
// The vote info of a specific dapp
$ localhost:1317/hdac/voter?hash=0000000000000000000000000000000000000000000000000000000000000000

// Quantity of each vote in a specific voter
$ localhost:1317/hdac/voter?address=fridayxxxxxxxxxxxxx

// Both
$ localhost:1317/hdac/voter?address=fridayxxxxxxxxxxxxx&hash=0000000000000000000000000000000000000000000000000000000000000000
```

Issue
--
When creating an account or creating a contract in execution-engine, it becomes 32 bytes without prefix. In order to use this externally, discussion of the address structure is necessary. https://github.com/hdac-io/friday/issues/98