### PR TITLE
feat: support to claim

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.6.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1
+	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
 	github.com/hdac-io/tendermint v0.0.0-20200102054348-9a58be0e600b
 	github.com/mattn/go-isatty v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1 h1:eO5Xe6twdvDYB9TjfCtnROqg+iQGSWbcyx4RhrvKF7w=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.1/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640 h1:zMqdkSrqvlc9VuyTTeFiz4b5Fwj8zOfNo1VGW19Mcls=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679 h1:xdX2qinan
 github.com/hdac-io/bls-go-binary v0.0.0-20191223054157-fad152e9a679/go.mod h1:qG6qX5Hrs2noYc1lcWj3PEb64gc2VoGtmcghXK8trCw=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404 h1:9FvbWqlHq6n2ciDoBzfqZj4Nri+cs34of5D2SHQhfLs=
 github.com/hdac-io/btcutil v0.0.0-20191220081549-27e3c0391404/go.mod h1:PQwlReOMYFpmYFt9Mtnw06XeVTjkjFZLs8/v0gwoW+0=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640 h1:zMqdkSrqvlc9VuyTTeFiz4b5Fwj8zOfNo1VGW19Mcls=
-github.com/hdac-io/casperlabs-ee-grpc-go-util v0.5.2-0.20200414030204-8b1770f5a640/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.6.0 h1:qicadX+N8c+piWi+eD/hOeY8Rs/sCb/lHrWLl0k+zzc=
+github.com/hdac-io/casperlabs-ee-grpc-go-util v0.6.0/go.mod h1:WakxSanxTmCA9D/VB2EBWH0sEwXTyUOrGbTk7HcO8Hc=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=

--- a/integration_tests/lib/cmd.py
+++ b/integration_tests/lib/cmd.py
@@ -344,6 +344,14 @@ def unvote(passphrase: str, hash: str, amount: str, fee: str, gas_price: int, fr
     client_home = os.path.join(os.environ["HOME"], client_home)
     return _tx_executor("clif hdac unvote {} {} {} {} --from {} --node {} --home {}", passphrase, hash, amount, fee, gas_price, from_value, node, client_home)
 
+def claim_reward(passphrase: str, fee: str, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac claim reward {} {} --from {} --node {} --home {}", passphrase, fee, gas_price, from_value, node, client_home)
+
+def claim_commission(passphrase: str, fee: str, gas_price: int, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    return _tx_executor("clif hdac claim commission {} {} --from {} --node {} --home {}", passphrase, fee, gas_price, from_value, node, client_home)
+
 def get_balance(from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
     client_home = os.path.join(os.environ["HOME"], client_home)
     res = _process_executor("clif hdac getbalance --from {} --node {} --home {}", from_value, node, client_home, need_output=True)
@@ -362,6 +370,16 @@ def get_delegator(validator_address: str, from_value: str, node: str = "tcp://lo
 def get_voter(hash: str, from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
     client_home = os.path.join(os.environ["HOME"], client_home)
     res = _process_executor("clif hdac voter {} --from {} --node {} --home {}", hash, from_value, node, client_home, need_output=True)
+    return res
+
+def get_reward(from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac getreward --from {} --node {} --home {}", from_value, node, client_home, need_output=True)
+    return res
+
+def get_commission(from_value: str, node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):
+    client_home = os.path.join(os.environ["HOME"], client_home)
+    res = _process_executor("clif hdac getcommission --from {} --node {} --home {}", from_value, node, client_home, need_output=True)
     return res
 
 def create_validator(passphrase: str, from_value: str, pubkey: str, moniker: str, identity: str='""', website: str='""', details: str='""', node: str = "tcp://localhost:26657", client_home: str = '.test_clif'):

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -414,13 +414,13 @@ class TestSingleNode():
         print("======================Start test07_simple_vote_and_unvote======================")
 
         print("Vote token")
-        delegate_tx_hash = cmd.vote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
+        vote_tx_hash = cmd.vote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
         print("Tx sent. Waiting for vote")
 
         time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
-        is_ok = cmd.is_tx_ok(delegate_tx_hash)
+        is_ok = cmd.is_tx_ok(vote_tx_hash)
         assert(is_ok == True)
 
         res = cmd.get_voter(self.system_contract, self.info_anna['address'])
@@ -428,13 +428,56 @@ class TestSingleNode():
         assert(res[0]["amount"] == self.vote_amount_bigsun) 
 
         print("Unvote token")
-        redelegate_tx_hash = cmd.unvote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
+        unvote_tx_hash = cmd.unvote(self.wallet_password, self.system_contract, self.vote_amount, self.vote_fee, self.vote_gas, self.wallet_anna)
         print("Tx sent. Waiting for unvote")
 
         time.sleep(self.tx_block_time * 3 + 1)
 
         print("Check whether tx is ok or not")
-        is_ok = cmd.is_tx_ok(redelegate_tx_hash)
+        is_ok = cmd.is_tx_ok(unvote_tx_hash)
         assert(is_ok == True)
 
         print("======================Done test07_simple_vote_and_unvote======================")
+
+    def test08_simple_claim_reward_and_commission(self):
+        print("======================Start test08_simple_claim_reward_and_commission======================")
+
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        res = cmd.get_balance(self.info_anna['address'])
+        init_balance = res["value"]
+        assert(float(init_balance) == self.basic_coin_amount)
+
+        res = cmd.get_commission(self.info_anna['address'])
+        print("Output: ", res)
+        commission_value = res["value"]
+        assert(float(res["value"]) > 0) 
+
+        res = cmd.get_reward(self.info_anna['address'])
+        print("Output: ", res)
+        reward_value = res["value"]
+        assert(float(res["value"]) > 0) 
+
+        print("Claim reward token")
+        claim_reward_tx_hash = cmd.claim_reward(self.wallet_password, self.vote_fee, self.vote_gas, self.wallet_anna)
+        print("Tx sent. Waiting for claim reward")
+
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        res = cmd.get_balance(self.info_anna['address'])
+        print("Output: ", res)
+        add_reward_balance = res["value"]
+        assert(float(init_balance) < float(add_reward_balance))
+
+        print("Claim commission token")
+        claim_reward_tx_hash = cmd.claim_commission(self.wallet_password, self.vote_fee, self.vote_gas, self.wallet_anna)
+        print("Tx sent. Waiting for claim commission")
+
+        time.sleep(self.tx_block_time * 3 + 1)
+
+        res = cmd.get_balance(self.info_anna['address'])
+        print("Output: ", res)
+        add_reward_and_commission_balance = res["value"]
+        assert(float(add_reward_balance) < float(add_reward_and_commission_balance))
+
+        print("======================Done test08_simple_claim_reward_and_commission======================")

--- a/x/executionlayer/client/cli/query.go
+++ b/x/executionlayer/client/cli/query.go
@@ -347,3 +347,105 @@ func GetCmdQueryVoter(cdc *codec.Codec) *cobra.Command {
 
 	return cmd
 }
+
+// GetCmdQueryReward is a getter of the reward of the address
+func GetCmdQueryReward(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "getreward --from <from>",
+		Short: "Get reward of address",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			var addr sdk.AccAddress
+			var err error
+			addr, err = cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
+			if err != nil {
+				kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+				if err != nil {
+					return err
+				}
+
+				keyInfo, err := kb.Get(valueFromFromFlag)
+				if err != nil {
+					return err
+				}
+
+				addr = keyInfo.GetAddress()
+			}
+
+			var out types.QueryExecutionLayerResp
+
+			queryData := types.NewQueryGetReward(addr)
+			bz := cdc.MustMarshalJSON(queryData)
+
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryreward", types.ModuleName), bz)
+			if err != nil {
+				fmt.Printf("no reward data of input")
+				return nil
+			}
+			cdc.MustUnmarshalJSON(res, &out)
+
+			out.Value = string(cliutil.ToHdac(cliutil.Bigsun(out.Value)))
+
+			return cliCtx.PrintOutput(out)
+		},
+	}
+
+	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
+
+	return cmd
+}
+
+// GetCmdQueryCommission is a getter of the commission of the address
+func GetCmdQueryCommission(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "getcommission --from <from>",
+		Short: "Get reward of address",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			valueFromFromFlag := viper.GetString(client.FlagFrom)
+			var addr sdk.AccAddress
+			var err error
+			addr, err = cliutil.GetAddress(cdc, cliCtx, valueFromFromFlag)
+			if err != nil {
+				kb, err := client.NewKeyBaseFromDir(viper.GetString(client.FlagHome))
+				if err != nil {
+					return err
+				}
+
+				keyInfo, err := kb.Get(valueFromFromFlag)
+				if err != nil {
+					return err
+				}
+
+				addr = keyInfo.GetAddress()
+			}
+
+			var out types.QueryExecutionLayerResp
+
+			queryData := types.NewQueryGetCommission(addr)
+			bz := cdc.MustMarshalJSON(queryData)
+
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/queryreward", types.ModuleName), bz)
+			if err != nil {
+				fmt.Printf("no reward data of input")
+				return nil
+			}
+			cdc.MustUnmarshalJSON(res, &out)
+
+			out.Value = string(cliutil.ToHdac(cliutil.Bigsun(out.Value)))
+
+			return cliCtx.PrintOutput(out)
+		},
+	}
+
+	cmd.Flags().String(client.FlagHome, DefaultClientHome, "Custom local path of client's home dir")
+	cmd.Flags().String(client.FlagFrom, "", "Executor's identity (one of wallet alias, address, nickname)")
+
+	return cmd
+}

--- a/x/executionlayer/client/cli/root.go
+++ b/x/executionlayer/client/cli/root.go
@@ -28,12 +28,15 @@ func GetHdacCustomCmd(cdc *codec.Codec) *cobra.Command {
 		GetCmdEditValidator(cdc),
 		GetCmdVote(cdc),
 		GetCmdUnvote(cdc),
+		GetCmdClaimReward(cdc),
 
 		// Query
 		GetCmdQueryBalance(cdc),
 		GetCmdQueryValidator(cdc),
 		GetCmdQueryDelegator(cdc),
 		GetCmdQueryVoter(cdc),
+		GetCmdQueryReward(cdc),
+		GetCmdQueryCommission(cdc),
 	)...)
 	return hdacCustomTxCmd
 }

--- a/x/executionlayer/client/rest/msgCreator_test.go
+++ b/x/executionlayer/client/rest/msgCreator_test.go
@@ -213,6 +213,50 @@ func TestRESTUnvote(t *testing.T) {
 	require.NotNil(t, msgs)
 }
 
+func TestRESTClaimReward(t *testing.T) {
+	_, _, writer, clictx, basereq := prepare()
+
+	// Body
+	claimReq := claimReq{
+		BaseReq:            basereq,
+		RewardOrCommission: types.RewardValue,
+		Amount:             "100000000",
+		Fee:                "10000000",
+	}
+
+	// http.request
+	body := clictx.Codec.MustMarshalJSON(claimReq)
+	req := mustNewRequest(t, "POST", fmt.Sprintf("/%s/claim", types.ModuleName), bytes.NewReader(body))
+
+	outputBasereq, msgs, err := claimMsgCreator(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputBasereq, basereq)
+	require.NotNil(t, msgs)
+}
+
+func TestRESTClaimCommission(t *testing.T) {
+	_, _, writer, clictx, basereq := prepare()
+
+	// Body
+	claimReq := claimReq{
+		BaseReq:            basereq,
+		RewardOrCommission: types.CommissionValue,
+		Amount:             "100000000",
+		Fee:                "10000000",
+	}
+
+	// http.request
+	body := clictx.Codec.MustMarshalJSON(claimReq)
+	req := mustNewRequest(t, "POST", fmt.Sprintf("/%s/claim", types.ModuleName), bytes.NewReader(body))
+
+	outputBasereq, msgs, err := claimMsgCreator(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, outputBasereq, basereq)
+	require.NotNil(t, msgs)
+}
+
 func TestRESTBalance(t *testing.T) {
 	fromAddr, _, writer, clictx, _ := prepare()
 
@@ -299,6 +343,26 @@ func TestRESTGetVoterFromAll(t *testing.T) {
 	hash := hex.EncodeToString(types.SYSTEM_ACCOUNT)
 
 	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/voter?hash=%s&address=%s", types.ModuleName, hash, fromAddr), nil)
+	res, err := getVoterQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetReward(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/reward?address=%s", types.ModuleName, fromAddr), nil)
+	res, err := getVoterQuerying(writer, clictx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestRESTGetCommission(t *testing.T) {
+	fromAddr, _, writer, clictx, _ := prepare()
+
+	req := mustNewRequest(t, "GET", fmt.Sprintf("%s/commission?address=%s", types.ModuleName, fromAddr), nil)
 	res, err := getVoterQuerying(writer, clictx, req)
 
 	require.NoError(t, err)

--- a/x/executionlayer/client/rest/rest.go
+++ b/x/executionlayer/client/rest/rest.go
@@ -131,7 +131,7 @@ func getBalanceHandler(cliCtx context.CLIContext, storeName string) http.Handler
 			return
 		}
 
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/querybalance", storeName), bz)
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/querybalancedetail", storeName), bz)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/executionlayer/types/codec.go
+++ b/x/executionlayer/types/codec.go
@@ -25,4 +25,5 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgRedelegate{}, "executionengine/Redelegate", nil)
 	cdc.RegisterConcrete(MsgVote{}, "executionengine/Vote", nil)
 	cdc.RegisterConcrete(MsgUnvote{}, "executionengine/Unvote", nil)
+	cdc.RegisterConcrete(MsgClaim{}, "executionengine/Claim", nil)
 }

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -609,3 +609,53 @@ func (msg MsgUnvote) GetSignBytes() []byte {
 func (msg MsgUnvote) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.FromAddress}
 }
+
+//______________________________________________________________________
+type MsgClaim struct {
+	ContractAddress    string         `json:"contract_address" yaml:"contract_address"`
+	FromAddress        sdk.AccAddress `json:"from_address" yaml:"from_address"`
+	RewardOrCommission bool           `json:"reward_or_commission" yaml:"reward_or_commission"`
+	Fee                string         `json:"fee" yaml:"fee"`
+	GasPrice           uint64         `json:"gas_price" yaml:"gas_price"`
+}
+
+// NewMsgClaim is a constructor function for MsgSetName
+func NewMsgClaim(
+	tokenContractAddress string,
+	fromAddress sdk.AccAddress,
+	rewardOrCommission bool,
+	fee string,
+	gasPrice uint64,
+) MsgClaim {
+	return MsgClaim{
+		ContractAddress:    tokenContractAddress,
+		FromAddress:        fromAddress,
+		RewardOrCommission: rewardOrCommission,
+		Fee:                fee,
+		GasPrice:           gasPrice,
+	}
+}
+
+// Route should return the name of the module
+func (msg MsgClaim) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgClaim) Type() string { return "executionengine" }
+
+// ValidateBasic runs stateless checks on the message
+func (msg MsgClaim) ValidateBasic() sdk.Error {
+	if msg.FromAddress.Equals(sdk.AccAddress("")) {
+		return sdk.ErrUnknownRequest("Address cannot be empty")
+	}
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgClaim) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgClaim) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.FromAddress}
+}

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -44,6 +44,12 @@ type QueryExecutionLayerResp struct {
 	Value string `json:"value"`
 }
 
+func NewQueryExecutionLayerResp(value string) QueryExecutionLayerResp {
+	return QueryExecutionLayerResp{
+		Value: value,
+	}
+}
+
 // implement fmt.Stringer
 func (q QueryExecutionLayerResp) String() string {
 	return fmt.Sprintf("Value: %s", q.Value)
@@ -87,4 +93,36 @@ func NewQueryVoterParams(address sdk.AccAddress, hash []byte) QueryVoterParams {
 		Address: address,
 		Hash:    hash,
 	}
+}
+
+// QueryGetReward payload for reward query
+type QueryGetReward struct {
+	Address sdk.AccAddress `json:"address"`
+}
+
+func NewQueryGetReward(address sdk.AccAddress) QueryGetReward {
+	return QueryGetReward{
+		Address: address,
+	}
+}
+
+// implement fmt.Stringer
+func (q QueryGetReward) String() string {
+	return fmt.Sprintf("Query public key or readable name: %s", q.Address)
+}
+
+// QueryGetCommission payload for commission query
+type QueryGetCommission struct {
+	Address sdk.AccAddress `json:"address"`
+}
+
+func NewQueryGetCommission(address sdk.AccAddress) QueryGetCommission {
+	return QueryGetCommission{
+		Address: address,
+	}
+}
+
+// implement fmt.Stringer
+func (q QueryGetCommission) String() string {
+	return fmt.Sprintf("Query public key or readable name: %s", q.Address)
 }

--- a/x/executionlayer/types/types.go
+++ b/x/executionlayer/types/types.go
@@ -14,18 +14,19 @@ const (
 	MintContractName = "mint"
 	PosContractName  = "pos"
 
-	ProxyContractName          = "client_api_proxy"
-	TransferMethodName         = "transfer_to_account"
-	PaymentMethodName          = "standard_payment"
-	BondMethodName             = "bond"
-	UnbondMethodName           = "unbond"
-	DelegateMethodName         = "delegate"
-	UndelegateMethodName       = "undelegate"
-	RedelegateMethodName       = "redelegate"
-	VoteMethodName             = "vote"
-	UnvoteMethodName           = "unvote"
-	StepMethodName             = "step"
-	WriteTotalSupplyMethodName = "write_genesis_total_supply"
+	ProxyContractName         = "client_api_proxy"
+	TransferMethodName        = "transfer_to_account"
+	PaymentMethodName         = "standard_payment"
+	BondMethodName            = "bond"
+	UnbondMethodName          = "unbond"
+	DelegateMethodName        = "delegate"
+	UndelegateMethodName      = "undelegate"
+	RedelegateMethodName      = "redelegate"
+	VoteMethodName            = "vote"
+	UnvoteMethodName          = "unvote"
+	StepMethodName            = "step"
+	ClaimRewardMethodName     = "claim_reward"
+	ClaimCommissionMethodName = "claim_commission"
 
 	SYSTEM_ACCOUNT_BALANCE       = "1000000000000000000000000000000"
 	TRANSFER_BALANCE             = "999999999999000000000000000000"
@@ -34,6 +35,11 @@ const (
 	BASIC_GAS                    = 30000000
 
 	DECIMAL_POINT_POS = 18
+
+	RewardString     = "reward"
+	CommissionString = "commission"
+	RewardValue      = true
+	CommissionValue  = false
 )
 
 // UnitHashMap used to define Unit account structure


### PR DESCRIPTION
Before
--
https://github.com/hdac-io/casperlabs-ee-grpc-go-util/pull/19

Content 
--
- fixed balance route in rest
- support to claim

Example
--
- claim cli
```
$ clif hdac claim commission 0.001 80000000 --from alsa

$ clif hdac claim reward 0.001 80000000 --from alsa
```

- Get reward cli
```
$ clif hdac getreward --from alsa
```

- Get commission cli
```
$ clif hdac getcommission --from alsa
```

- claim rest
```
[POST]
$ https://localhost:1317/hdac/claim
```

- Get reward rest
```
[GET]
$ http://localhost:1317/hdac/reward?address=friday135260rslw2gkhpph2gjclm5zvvaeaf9qw7tknm
```

- Get commission rest
```
[GET]
$ http://localhost:1317/hdac/commission?address=friday135260rslw2gkhpph2gjclm5zvvaeaf9qw7tknm
```