### PR TITLE
refactor: query result format

### DIFF
--- a/integration_tests/test_multi_node_simple_cli.py
+++ b/integration_tests/test_multi_node_simple_cli.py
@@ -179,12 +179,12 @@ class TestMultiNodeSimple:
         print("At {}".format(picked_node))
 
         res = cmd.get_balance(self.wallet_anna, node=picked_node)
-        assert((self.basic_coin_amount + float(self.transfer_amount)) * 0.95 < float(res["value"]))
+        assert((self.basic_coin_amount + float(self.transfer_amount)) * 0.95 < float(res))
 
         picked_node = self.get_node_randomly()
         print("At {}".format(picked_node))
         res = cmd.get_balance(self.wallet_elsa, node=picked_node)
-        assert(float(res["value"]) < self.basic_coin_amount - float(self.transfer_amount))
+        assert(float(res) < self.basic_coin_amount - float(self.transfer_amount))
 
         print("======================Done test01_transfer_to======================")
 
@@ -215,10 +215,10 @@ class TestMultiNodeSimple:
         for node in self.nodes_address[:3]:
             print("Test of {}".format(node))
             res = cmd.get_balance(self.wallet_anna, node=node)
-            print("Balance of 'anna': ", float(res["value"]))
+            print("Balance of 'anna': ", float(res))
 
             res = cmd.get_balance(self.wallet_bryan, node=node)
-            print("Balance of 'anna': ", float(res["value"]))
+            print("Balance of 'anna': ", float(res))
             print("{} OK".format(node))
 
         print("======================End test01_1_transfer_to_nonexistent_account======================")
@@ -272,7 +272,7 @@ class TestMultiNodeSimple:
 
         # We cannot sure the status of each wallet. Just validate Tx and skip value comparison
         #res_transfer = cmd.get_balance("address", self.info_anna['address'], node=picked_node)
-        #assert(int(res_transfer['value']) == int(self.basic_coin + self.transfer_amount))
+        #assert(int(res_transfer) == int(self.basic_coin + self.transfer_amount))
 
         print("Try to transfer to nickname sender")
         tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], self.transfer_amount,

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -156,10 +156,10 @@ class TestSingleNode():
 
         res = cmd.get_balance(self.wallet_elsa)
         print("Output: ", res)
-        assert(float(res["value"]) == self.basic_coin_amount) 
+        assert(float(res) == self.basic_coin_amount) 
 
         res = cmd.get_balance(self.wallet_anna)
-        assert(float(res["value"]) == self.basic_coin_amount)
+        assert(float(res) == self.basic_coin_amount)
         print("======================Done test00_get_balance======================")
 
 
@@ -179,10 +179,10 @@ class TestSingleNode():
 
         print("Balance checking after transfer..")
         res = cmd.get_balance(self.wallet_anna)
-        assert(float(res["value"]) == self.basic_coin_amount + float(self.transfer_amount))
+        assert(float(res) == self.basic_coin_amount + float(self.transfer_amount))
 
         res = cmd.get_balance(self.wallet_elsa)
-        assert(float(res["value"]) < self.basic_coin_amount - float(self.transfer_amount))
+        assert(float(res) < self.basic_coin_amount - float(self.transfer_amount))
 
         print("======================Done test01_transfer_to======================")
 
@@ -205,7 +205,7 @@ class TestSingleNode():
         res_before = cmd.get_balance(self.wallet_anna)
 
         print("Try to send more money than bonding. Invalid tx expected")
-        tx_hash_after_bond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before['value']) - self.basic_bond / 2),
+        tx_hash_after_bond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before) - self.basic_bond / 2),
                                              self.transfer_fee, self.transfer_gas, self.wallet_anna)
         
         print("Tx sent. Waiting for validation")
@@ -218,7 +218,7 @@ class TestSingleNode():
         print("Balance checking after bonding")
         res_after = cmd.get_balance(self.wallet_anna)
         # Reason: Just enough value to ensure that tx become invalid
-        assert(self.basic_bond < int(res_after["value"]))
+        assert(self.basic_bond < int(res_after))
 
         print("Unbond and try to transfer")
         print("Unbond first")
@@ -232,7 +232,7 @@ class TestSingleNode():
         assert(is_ok == True)
 
         print("Try to transfer. Will be confirmed in this time")
-        tx_hash_after_unbond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before['value']) - self.basic_bond / 2),
+        tx_hash_after_unbond = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], int(int(res_before) - self.basic_bond / 2),
                                                self.transfer_fee, self.transfer_gas, self.wallet_anna)
         
         print("Tx sent. Waiting for validation")
@@ -245,7 +245,7 @@ class TestSingleNode():
         print("Balance checking after bonding")
         res_after_after = cmd.get_balance(self.wallet_anna)
         # Reason: Just enough value to ensure that tx become invalid
-        assert(int(res_after_after["value"]) == self.basic_coin + int(res_before['value']) - self.basic_bond)
+        assert(int(res_after_after) == self.basic_coin + int(res_before) - self.basic_bond)
 
         print("======================Done test02_bond_and_unbond======================")
 
@@ -318,7 +318,7 @@ class TestSingleNode():
 
         print("Check wallet by address. Should be match with wallet info")
         res_transfer = cmd.get_balance(self.info_anna['address'])
-        assert(float(res_transfer['value']) == self.basic_coin_amount + float(self.transfer_amount))
+        assert(float(res_transfer) == self.basic_coin_amount + float(self.transfer_amount))
 
         print("Try to transfer to nickname sender")
         tx_hash_transfer = cmd.transfer_to(self.wallet_password, self.info_elsa['address'], self.transfer_amount,
@@ -333,7 +333,7 @@ class TestSingleNode():
 
         print("Check wallet by address. Should be match with wallet info")
         res_transfer = cmd.get_balance(self.info_anna['address'])
-        assert(float(self.basic_coin_amount *0.9) < float(res_transfer['value']) < self.basic_coin_amount)
+        assert(float(self.basic_coin_amount *0.9) < float(res_transfer) < self.basic_coin_amount)
 
         print("======================Done test04_transfer_to_by_nickname======================")
 
@@ -445,18 +445,18 @@ class TestSingleNode():
         time.sleep(self.tx_block_time * 3 + 1)
 
         res = cmd.get_balance(self.info_anna['address'])
-        init_balance = res["value"]
+        init_balance = res
         assert(float(init_balance) == self.basic_coin_amount)
 
         res = cmd.get_commission(self.info_anna['address'])
         print("Output: ", res)
-        commission_value = res["value"]
-        assert(float(res["value"]) > 0) 
+        commission_value = res
+        assert(float(res) > 0) 
 
         res = cmd.get_reward(self.info_anna['address'])
         print("Output: ", res)
-        reward_value = res["value"]
-        assert(float(res["value"]) > 0) 
+        reward_value = res
+        assert(float(res) > 0) 
 
         print("Claim reward token")
         claim_reward_tx_hash = cmd.claim_reward(self.wallet_password, self.vote_fee, self.vote_gas, self.wallet_anna)
@@ -466,7 +466,7 @@ class TestSingleNode():
 
         res = cmd.get_balance(self.info_anna['address'])
         print("Output: ", res)
-        add_reward_balance = res["value"]
+        add_reward_balance = res
         assert(float(init_balance) < float(add_reward_balance))
 
         print("Claim commission token")
@@ -477,7 +477,7 @@ class TestSingleNode():
 
         res = cmd.get_balance(self.info_anna['address'])
         print("Output: ", res)
-        add_reward_and_commission_balance = res["value"]
+        add_reward_and_commission_balance = res
         assert(float(add_reward_balance) < float(add_reward_and_commission_balance))
 
         print("======================Done test08_simple_claim_reward_and_commission======================")

--- a/x/executionlayer/alias.go
+++ b/x/executionlayer/alias.go
@@ -31,7 +31,6 @@ type (
 	MsgCreateValidator        = types.MsgCreateValidator
 	MsgEditValidator          = types.MsgEditValidator
 	UnitHashMap               = types.UnitHashMap
-	QueryExecutionLayerResp   = types.QueryExecutionLayerResp
 	QueryExecutionLayerDetail = types.QueryExecutionLayerDetail
 	QueryGetBalanceDetail     = types.QueryGetBalanceDetail
 	QueryValidatorParams      = types.QueryValidatorParams

--- a/x/executionlayer/client/cli/query.go
+++ b/x/executionlayer/client/cli/query.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/friday/client"
 	"github.com/hdac-io/friday/client/context"
 	"github.com/hdac-io/friday/codec"
@@ -59,7 +62,6 @@ func GetCmdQueryBalance(cdc *codec.Codec) *cobra.Command {
 				addr = keyInfo.GetAddress()
 			}
 
-			var out types.QueryExecutionLayerResp
 			blockhashstr := viper.GetString(FlagBlockHash)
 
 			queryData := types.QueryGetBalanceDetail{
@@ -73,11 +75,16 @@ func GetCmdQueryBalance(cdc *codec.Codec) *cobra.Command {
 				fmt.Printf("no balance data of input")
 				return nil
 			}
-			cdc.MustUnmarshalJSON(res, &out)
+			out := &state.Value{}
+			err = jsonpb.Unmarshal(bytes.NewReader(res), out)
+			if err != nil {
+				fmt.Printf("Faild to json unmarshal, %s", err)
+			}
 
-			out.Value = string(cliutil.ToHdac(cliutil.Bigsun(out.Value)))
+			balance := string(cliutil.ToHdac(cliutil.Bigsun(out.GetStringValue())))
 
-			return cliCtx.PrintOutput(out)
+			_, err = fmt.Println(balance)
+			return err
 		},
 	}
 
@@ -100,7 +107,6 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 			data := args[1]
 			path := args[2]
 
-			var out types.QueryExecutionLayerResp
 			blockhash := viper.GetString(FlagBlockHash)
 
 			queryData := types.QueryExecutionLayerDetail{
@@ -112,13 +118,24 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 			bz := cdc.MustMarshalJSON(queryData)
 
 			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/querydetail", types.ModuleName), bz)
+
 			if err != nil {
-				fmt.Printf("could not resolve data - %s %s %s\n", dataType, data, path)
+				fmt.Printf("could not resolve data - %s %s %s\nerr : %s\n", dataType, data, path, err.Error())
 				return nil
 			}
-			cdc.MustUnmarshalJSON(res, &out)
 
-			return cliCtx.PrintOutput(out)
+			value := &state.Value{}
+			err = jsonpb.Unmarshal(bytes.NewReader(res), value)
+
+			marshaler := jsonpb.Marshaler{Indent: "  "}
+			valueStr, err := marshaler.MarshalToString(value)
+			if err != nil {
+				fmt.Printf("could not resolve data - %s %s %s\nerr : %s\n", dataType, data, path, err.Error())
+				return nil
+			}
+
+			_, err = fmt.Println(valueStr)
+			return err
 		},
 	}
 
@@ -375,8 +392,6 @@ func GetCmdQueryReward(cdc *codec.Codec) *cobra.Command {
 				addr = keyInfo.GetAddress()
 			}
 
-			var out types.QueryExecutionLayerResp
-
 			queryData := types.NewQueryGetReward(addr)
 			bz := cdc.MustMarshalJSON(queryData)
 
@@ -385,11 +400,16 @@ func GetCmdQueryReward(cdc *codec.Codec) *cobra.Command {
 				fmt.Printf("no reward data of input")
 				return nil
 			}
-			cdc.MustUnmarshalJSON(res, &out)
+			out := &state.Value{}
+			err = jsonpb.Unmarshal(bytes.NewReader(res), out)
+			if err != nil {
+				fmt.Printf("Faild to json unmarshal, %s", err)
+			}
 
-			out.Value = string(cliutil.ToHdac(cliutil.Bigsun(out.Value)))
+			balance := string(cliutil.ToHdac(cliutil.Bigsun(out.GetStringValue())))
 
-			return cliCtx.PrintOutput(out)
+			_, err = fmt.Println(balance)
+			return err
 		},
 	}
 
@@ -426,8 +446,6 @@ func GetCmdQueryCommission(cdc *codec.Codec) *cobra.Command {
 				addr = keyInfo.GetAddress()
 			}
 
-			var out types.QueryExecutionLayerResp
-
 			queryData := types.NewQueryGetCommission(addr)
 			bz := cdc.MustMarshalJSON(queryData)
 
@@ -436,11 +454,16 @@ func GetCmdQueryCommission(cdc *codec.Codec) *cobra.Command {
 				fmt.Printf("no reward data of input")
 				return nil
 			}
-			cdc.MustUnmarshalJSON(res, &out)
+			out := &state.Value{}
+			err = jsonpb.Unmarshal(bytes.NewReader(res), out)
+			if err != nil {
+				fmt.Printf("Faild to json unmarshal, %s", err)
+			}
 
-			out.Value = string(cliutil.ToHdac(cliutil.Bigsun(out.Value)))
+			balance := string(cliutil.ToHdac(cliutil.Bigsun(out.GetStringValue())))
 
-			return cliCtx.PrintOutput(out)
+			_, err = fmt.Println(balance)
+			return err
 		},
 	}
 

--- a/x/executionlayer/client/cli/tx.go
+++ b/x/executionlayer/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -48,9 +49,12 @@ func GetCmdContractRun(cdc *codec.Codec) *cobra.Command {
 			switch sessionType {
 			case util.WASM:
 				sessionCode = util.LoadWasmFile(args[1])
-			case util.HASH:
-			case util.UREF:
-				sessionCode = util.DecodeHexString(args[1])
+			case util.HASH, util.UREF:
+				src, err := base64.StdEncoding.DecodeString(args[1])
+				if err != nil {
+					return err
+				}
+				sessionCode = src
 			case util.NAME:
 				sessionCode = []byte(args[1])
 			default:

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -169,7 +169,10 @@ func queryAllValidator(ctx sdk.Context, keeper ExecutionLayerKeeper) ([]byte, sd
 // GetQueryResult queries with whole parameters
 func getQueryResult(ctx sdk.Context, k ExecutionLayerKeeper,
 	blockhashStr string, keyType string, keyData string, path string) (storedvalue.StoredValue, error) {
-	arrPath := strings.Split(path, "/")
+	arrPath := []string{}
+	if path != "" {
+		arrPath = strings.Split(path, "/")
+	}
 
 	var blockhash []byte
 	var err error

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -39,22 +39,6 @@ func (q QueryGetBalanceDetail) String() string {
 	return fmt.Sprintf("State: %s\nQuery public key or readable name: %s", q.BlockHash, q.Address)
 }
 
-// QueryExecutionLayerResp is used for response of EE query
-type QueryExecutionLayerResp struct {
-	Value string `json:"value"`
-}
-
-func NewQueryExecutionLayerResp(value string) QueryExecutionLayerResp {
-	return QueryExecutionLayerResp{
-		Value: value,
-	}
-}
-
-// implement fmt.Stringer
-func (q QueryExecutionLayerResp) String() string {
-	return fmt.Sprintf("Value: %s", q.Value)
-}
-
 // defines the params for the following queries:
 // - 'custom/%s/validator'
 type QueryValidatorParams struct {


### PR DESCRIPTION
Content
--
- Using state.Value in query result.
- hash, uref using base64
- fix to query about empty path

Example
--
- query to empty path
```
$ clif contract query address system ""

{
  "account": {
    "publicKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
    "purseId": {
      "uref": "xku1iPAAyhsmVki1Pa53VZVF/pPCT9X5QGAv69zckWg=",
      "accessRights": "READ_ADD_WRITE"
    },
    "namedKeys": [
      {
        "name": "client_api_proxy",
        "key": {
          "hash": {
            "hash": "gugAzkxGTdR7iT2otcj6XG61l2QZ6FctybKFZaVFX+Y="
          }
        }
      },
      {
        "name": "mint",
        "key": {
          "uref": {
            "uref": "w6B2vpJyVZhMbg0Sglbq1bNBiUh0Js4apSv6pQzw/dk=",
            "accessRights": "READ_ADD_WRITE"
          }
        }
      },
      {
        "name": "pos",
        "key": {
          "uref": {
            "uref": "5rixHWC5pAT9MnzofTEOls2CvqklMcNP8tZbw0eQiIk=",
            "accessRights": "READ_ADD_WRITE"
          }
        }
      }
    ],
    "associatedKeys": [
      {
        "publicKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
        "weight": 1
      }
    ],
    "actionThresholds": {
      "deploymentThreshold": 1,
      "keyManagementThreshold": 1
    }
  }
}
```
- contarct run using base64 hash
```
// client_api_proxy : gugAzkxGTdR7iT2otcj6XG61l2QZ6FctybKFZaVFX+Y=

$ clif contract run hash gugAzkxGTdR7iT2otcj6XG61l2QZ6FctybKFZaVFX+Y= '[{"name":"method","value":{"stringValue":"bond"}},{"name":"amount","value":{"bigInt":{"value":"10000000000000000000","bitWidth":512}}}]' 0.01 300000000 --from alsa
```