### PR TITLE
Resolve JSON unmarshaling issue when send vote tx with REST

### DIFF
--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -245,7 +245,7 @@ class TestSingleNode():
 
         print("Balance checking after bonding")
         res_after_after = cmd.get_balance(self.wallet_anna)
-        assert(int(res_after_after) < self.basic_coin_amount * 29 / 30)
+        assert(int(res_after_after) < self.basic_coin_amount / 30)
 
         print("======================Done test02_bond_and_unbond======================")
 

--- a/x/executionlayer/types/msgs.go
+++ b/x/executionlayer/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/util"
 	sdk "github.com/hdac-io/friday/types"
@@ -481,11 +482,11 @@ func (msg MsgRedelegate) GetSigners() []sdk.AccAddress {
 
 //______________________________________________________________________
 type MsgVote struct {
-	ContractAddress       string              `json:"contract_address" yaml:"contract_address"`
-	FromAddress           sdk.AccAddress      `json:"from_address" yaml:"from_address"`
-	TargetContractAddress sdk.ContractAddress `json:"target_contract_address" yaml:"target_contract_address"`
-	Amount                string              `json:"amount" yaml:"amount"`
-	Fee                   string              `json:"fee" yaml:"fee"`
+	ContractAddress       string         `json:"contract_address" yaml:"contract_address"`
+	FromAddress           sdk.AccAddress `json:"from_address" yaml:"from_address"`
+	TargetContractAddress string         `json:"target_contract_address" yaml:"target_contract_address"`
+	Amount                string         `json:"amount" yaml:"amount"`
+	Fee                   string         `json:"fee" yaml:"fee"`
 }
 
 // NewMsgVote is a constructor function for MsgSetName
@@ -498,7 +499,7 @@ func NewMsgVote(
 	return MsgVote{
 		ContractAddress:       tokenContractAddress,
 		FromAddress:           fromAddress,
-		TargetContractAddress: targetContractAddress,
+		TargetContractAddress: targetContractAddress.String(),
 		Amount:                amount,
 		Fee:                   fee,
 	}
@@ -515,7 +516,22 @@ func (msg MsgVote) ValidateBasic() sdk.Error {
 	if msg.FromAddress.Equals(sdk.AccAddress("")) {
 		return sdk.ErrUnknownRequest("Address cannot be empty")
 	}
-	if len(msg.TargetContractAddress.Bytes()) != 32 {
+
+	var contractAddr sdk.ContractAddress
+	var err error
+	if strings.HasPrefix(msg.TargetContractAddress, sdk.Bech32PrefixContractURef) {
+		contractAddr, err = sdk.ContractUrefAddressFromBech32(msg.TargetContractAddress)
+	} else if strings.HasPrefix(msg.TargetContractAddress, sdk.Bech32PrefixContractHash) {
+		contractAddr, err = sdk.ContractHashAddressFromBech32(msg.TargetContractAddress)
+	} else {
+		err = sdk.ErrUnknownRequest("Contract address is not valid")
+	}
+
+	if err != nil {
+		return sdk.ErrUnknownAddress(err.Error())
+	}
+
+	if len(contractAddr.Bytes()) != 32 {
 		return sdk.ErrUnknownRequest("Hash must be 32 bytes")
 	}
 	return nil
@@ -533,11 +549,11 @@ func (msg MsgVote) GetSigners() []sdk.AccAddress {
 
 //______________________________________________________________________
 type MsgUnvote struct {
-	ContractAddress       string              `json:"contract_address" yaml:"contract_address"`
-	FromAddress           sdk.AccAddress      `json:"from_address" yaml:"from_address"`
-	TargetContractAddress sdk.ContractAddress `json:"target_contract_address" yaml:"target_contract_address"`
-	Amount                string              `json:"amount" yaml:"amount"`
-	Fee                   string              `json:"fee" yaml:"fee"`
+	ContractAddress       string         `json:"contract_address" yaml:"contract_address"`
+	FromAddress           sdk.AccAddress `json:"from_address" yaml:"from_address"`
+	TargetContractAddress string         `json:"target_contract_address" yaml:"target_contract_address"`
+	Amount                string         `json:"amount" yaml:"amount"`
+	Fee                   string         `json:"fee" yaml:"fee"`
 }
 
 // NewMsgUnvote is a constructor function for MsgSetName
@@ -550,7 +566,7 @@ func NewMsgUnvote(
 	return MsgUnvote{
 		ContractAddress:       tokenContractAddress,
 		FromAddress:           fromAddress,
-		TargetContractAddress: targetContractAddress,
+		TargetContractAddress: targetContractAddress.String(),
 		Amount:                amount,
 		Fee:                   fee,
 	}
@@ -567,7 +583,22 @@ func (msg MsgUnvote) ValidateBasic() sdk.Error {
 	if msg.FromAddress.Equals(sdk.AccAddress("")) {
 		return sdk.ErrUnknownRequest("Address cannot be empty")
 	}
-	if len(msg.TargetContractAddress.Bytes()) != 32 {
+
+	var contractAddr sdk.ContractAddress
+	var err error
+	if strings.HasPrefix(msg.TargetContractAddress, sdk.Bech32PrefixContractURef) {
+		contractAddr, err = sdk.ContractUrefAddressFromBech32(msg.TargetContractAddress)
+	} else if strings.HasPrefix(msg.TargetContractAddress, sdk.Bech32PrefixContractHash) {
+		contractAddr, err = sdk.ContractHashAddressFromBech32(msg.TargetContractAddress)
+	} else {
+		err = sdk.ErrUnknownRequest("Contract address is not valid")
+	}
+
+	if err != nil {
+		return sdk.ErrUnknownAddress(err.Error())
+	}
+
+	if len(contractAddr.Bytes()) != 32 {
 		return sdk.ErrUnknownRequest("Hash must be 32 bytes")
 	}
 	return nil


### PR DESCRIPTION
### As-is
- As `ContractAddress` types Interface
- In unmarshaling phase, it has error

### To-be
- Use string and convert `ContractAddress` in handler

### Known-issue
- Cannot send Uref address due to protobuf type issue
  - Duplicated `Key_Uref` type and 2nd `Key_Uref` has no `isKey_Value()`
  - Other types are classified with underscore (Hash, Local)
- Redundant code in handler
  - Will be modified at next version (When `Key_Uref` is utilized)