### PR TITLE
Private/jiyong toggle consensus module

### DIFF
--- a/cmd/nodef/testnet.go
+++ b/cmd/nodef/testnet.go
@@ -322,7 +322,7 @@ func collectGenFiles(
 		genFile := config.GenesisFile()
 
 		// overwrite each validator's genesis file to have a canonical genesis time
-		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime); err != nil {
+		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime, "friday"); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/hdac-io/casperlabs-ee-grpc-go-util v0.6.0
 	github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef
-	github.com/hdac-io/tendermint v0.32.8-0.20200508022932-eb53ac7c4ab9
+	github.com/hdac-io/tendermint v0.32.8-0.20200510224311-bc74d177bea9
 	github.com/mattn/go-isatty v0.0.8
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/hdac-io/casperlabs-ee-grpc-go-util v0.6.0/go.mod h1:WakxSanxTmCA9D/VB
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef h1:2Agvbgr7rAy4OwBETZ6a4VAXLXCbPDdLWw8Mz9zQcLw=
 github.com/hdac-io/iavl v0.0.0-20191220074654-211e1bd34eef/go.mod h1:ry8RH8MNJJhiO1VJeosYAsKrPu7X8Xy0B5D5UQvEiVM=
 github.com/hdac-io/tendermint v0.0.0-20191220055750-d875915aea37/go.mod h1:BronDynhlemRSl99OCZ3owAs/cTcDuw0BrgFmzasWPk=
-github.com/hdac-io/tendermint v0.32.8-0.20200508022932-eb53ac7c4ab9 h1:SwJdKV6uFLgQI+jDlA4d92lSvZ45Qr8ERr7C6c2L2zw=
-github.com/hdac-io/tendermint v0.32.8-0.20200508022932-eb53ac7c4ab9/go.mod h1:lQzldj9uvA4kkM+GH9Ty/bXNzAl9wWJEAa8iKt0+bMQ=
+github.com/hdac-io/tendermint v0.32.8-0.20200510224311-bc74d177bea9 h1:cxlEGdlboScFGYKj/m6KSPvlFOqYcdwZ0f94Xd3kyhk=
+github.com/hdac-io/tendermint v0.32.8-0.20200510224311-bc74d177bea9/go.mod h1:lQzldj9uvA4kkM+GH9Ty/bXNzAl9wWJEAa8iKt0+bMQ=
 github.com/herumi/bls-go-binary v0.0.0-20191119080710-898950e1a520/go.mod h1:uTBfU/n3h1aOYIl5nNTbLn5dUfNkF1P97JTaz3bdvro=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/integration_tests/lib/cmd.py
+++ b/integration_tests/lib/cmd.py
@@ -93,11 +93,11 @@ def daemon_check(proc: subprocess.Popen):
 ## Setup CLI
 #################
 
-def init_chain(moniker: str, chain_id: str) -> subprocess.Popen:
+def init_chain(moniker: str, consensus_module: str, chain_id: str) -> subprocess.Popen:
     """
     nodef init <moniker> --chain-id <chain-id>
     """
-    _ = _process_executor("nodef init {} --chain-id {}", moniker, chain_id)
+    _ = _process_executor("nodef init {} {} --chain-id {}", moniker, consensus_module, chain_id)
 
 
 def copy_manifest():

--- a/integration_tests/test_multi_node_simple_cli.py
+++ b/integration_tests/test_multi_node_simple_cli.py
@@ -39,7 +39,7 @@ class TestMultiNodeSimple:
     info_bryan = None
 
     basic_coin = "1000000000000000000000000000"
-    basic_stake = "1000000000000000000"
+    basic_stake = "10000000000000000000"
 
     multiplier = 10 ** 18
 

--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -13,6 +13,7 @@ class TestSingleNode():
 
     chain_id = "testchain"
     moniker = "testnode"
+    consensus_module = "friday"
 
     system_contract = "0000000000000000000000000000000000000000000000000000000000000000"
     anonymous_contract_address_hash = "fridaycontracthash1dl45lfet0wrsduxfeegwmskmmr8yhlpk6lk4qdpyhpjsffkymstq6ajv0a"
@@ -107,7 +108,7 @@ class TestSingleNode():
         cmd.whole_cleanup()
 
         print("Init chain")
-        cmd.init_chain(self.moniker, self.chain_id)
+        cmd.init_chain(self.moniker, self.consensus_module, self.chain_id)
         cmd.unsafe_reset_all()
         
         print("Copy manifest file")

--- a/server/start.go
+++ b/server/start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hdac-io/tendermint/p2p"
 	pvm "github.com/hdac-io/tendermint/privval"
 	"github.com/hdac-io/tendermint/proxy"
+	"github.com/hdac-io/tendermint/types"
 )
 
 // Tendermint full-node start flags
@@ -146,12 +147,19 @@ func startInProcess(ctx *Context, appCreator AppCreator) (*node.Node, error) {
 		return nil, err
 	}
 
-	UpgradeOldPrivValFile(cfg)
+	var privVal types.PrivValidator
+	switch cfg.Consensus.Module {
+	case "friday":
+		privVal = pvm.LoadOrGenFridayFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
+	case "tendermint":
+		UpgradeOldPrivValFile(cfg)
+		privVal = pvm.LoadOrGenFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
+	}
 
 	// create & start tendermint node
 	tmNode, err := node.NewNode(
 		cfg,
-		pvm.LoadOrGenFridayFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile()),
+		privVal,
 		nodeKey,
 		proxy.NewLocalClientCreator(app),
 		node.DefaultGenesisDocProviderFunc(cfg),

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -61,11 +61,12 @@ func displayInfo(cdc *codec.Codec, info printInfo) error {
 func InitCmd(ctx *server.Context, cdc *codec.Codec, mbm module.BasicManager,
 	defaultNodeHome string) *cobra.Command { // nolint: golint
 	cmd := &cobra.Command{
-		Use:   "init [moniker]",
+		Use:   "init [moniker] [consensus-module]",
 		Short: "Initialize private validator, p2p, genesis, and application configuration files",
 		Long:  `Initialize validators's and node's configuration files.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
+			ctx.Config.Consensus.Module = args[1]
 			config := ctx.Config
 			config.SetRoot(viper.GetString(cli.HomeFlag))
 
@@ -102,6 +103,7 @@ func InitCmd(ctx *server.Context, cdc *codec.Codec, mbm module.BasicManager,
 				}
 			}
 
+			genDoc.ConsensusModule = config.Consensus.Module
 			genDoc.ChainID = chainID
 			genDoc.Validators = nil
 			genDoc.AppState = appState

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -40,7 +40,7 @@ func TestInitCmd(t *testing.T) {
 	cdc := makeCodec()
 	cmd := InitCmd(ctx, cdc, testMbm, home)
 
-	require.NoError(t, cmd.RunE(nil, []string{"appnode-test"}))
+	require.NoError(t, cmd.RunE(nil, []string{"appnode-test", "friday"}))
 }
 
 func setupClientHome(t *testing.T) func() {
@@ -64,7 +64,7 @@ func TestEmptyState(t *testing.T) {
 	cdc := makeCodec()
 
 	cmd := InitCmd(ctx, cdc, testMbm, home)
-	require.NoError(t, cmd.RunE(nil, []string{"appnode-test"}))
+	require.NoError(t, cmd.RunE(nil, []string{"appnode-test", "friday"}))
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()
@@ -104,7 +104,7 @@ func TestStartStandAlone(t *testing.T) {
 	ctx := server.NewContext(cfg, logger)
 	cdc := makeCodec()
 	initCmd := InitCmd(ctx, cdc, testMbm, home)
-	require.NoError(t, initCmd.RunE(nil, []string{"appnode-test"}))
+	require.NoError(t, initCmd.RunE(nil, []string{"appnode-test", "friday"}))
 
 	app, err := mock.NewApp(home, logger)
 	require.Nil(t, err)

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -49,7 +49,7 @@ func TestMigrateGenesis(t *testing.T) {
 	require.Error(t, MigrateGenesisCmd(ctx, cdc).RunE(nil, []string{target, genesisPath}))
 
 	// Noop migration with minimal genesis
-	emptyGenesis := []byte(`{"chain_id":"test","app_state":{}}`)
+	emptyGenesis := []byte(`{"chain_id":"test","consensus_module": "tendermint", "app_state":{}}`)
 	err = ioutil.WriteFile(genesisPath, emptyGenesis, 0644)
 	require.Nil(t, err)
 	cmd := setupCmd("", "test2")

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -27,14 +27,15 @@ func ExportGenesisFile(genDoc *tmtypes.GenesisDoc, genFile string) error {
 // An error is returned if building or writing the configuration to file fails.
 func ExportGenesisFileWithTime(
 	genFile, chainID string, validators []tmtypes.GenesisValidator,
-	appState json.RawMessage, genTime time.Time,
+	appState json.RawMessage, genTime time.Time, consensusModule string,
 ) error {
 
 	genDoc := tmtypes.GenesisDoc{
-		GenesisTime: genTime,
-		ChainID:     chainID,
-		Validators:  validators,
-		AppState:    appState,
+		GenesisTime:     genTime,
+		ChainID:         chainID,
+		Validators:      validators,
+		AppState:        appState,
+		ConsensusModule: consensusModule,
 	}
 
 	if err := genDoc.ValidateAndComplete(); err != nil {
@@ -65,7 +66,12 @@ func InitializeNodeValidatorFiles(config *cfg.Config,
 		return nodeID, valPubKey, nil
 	}
 
-	valPubKey = privval.LoadOrGenFridayFilePV(pvKeyFile, pvStateFile).GetPubKey()
+	switch config.Consensus.Module {
+	case "friday":
+		valPubKey = privval.LoadOrGenFridayFilePV(pvKeyFile, pvStateFile).GetPubKey()
+	case "tendermint":
+		valPubKey = privval.LoadOrGenFilePV(pvKeyFile, pvStateFile).GetPubKey()
+	}
 
 	return nodeID, valPubKey, nil
 }

--- a/x/genutil/utils_test.go
+++ b/x/genutil/utils_test.go
@@ -17,5 +17,5 @@ func TestExportGenesisFileWithTime(t *testing.T) {
 	defer cleanup()
 
 	fname := filepath.Join(dir, "genesis.json")
-	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))
+	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now(), "friday"))
 }


### PR DESCRIPTION
Added parameter to init command for toggle to consensus module.

if you change the module in the same environment, Note that the file format of priv_validator_state.json changes.

Use: nodef init [moniker] [consensus-module]
ex)
friday - nodef init test friday
tendermint - nodef init test tendermint