### PR TITLE
build: remove node install in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"
   - export PATH="$PATH:$HOME/protoc/bin"
 install:
-  - npm install -g assemblyscript@0.9.1
   - make install
 before_script:
   - ./CasperLabs/execution-engine/target/release/casperlabs-engine-grpc-server $HOME/.casperlabs/.casper-node.sock -z& # for integration test.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You should install the packages below before you build the source.
 * [Rust](https://www.rust-lang.org/tools/install)
 * [Golang](https://golang.org/doc/install) >= 1.13
 * [protoc](http://google.github.io/proto-lens/installing-protoc.html) >= 3.6.1
-* [node](https://nodejs.org/en/download/)
 * make
 * cmake
 
@@ -50,7 +49,7 @@ You should launch execution engine grpc server first.
 
 ```sh
 cd friday
-./CasperLabs/execution-engine/target/release/casperlabs-engine-grpc-server $HOME/.casperlabs/.casper-node.sock&
+./CasperLabs/execution-engine/target/release/casperlabs-engine-grpc-server -z $HOME/.casperlabs/.casper-node.sock&
 ```
 
 And simply make it again!

--- a/scripts/install_casperlabs_ee.sh
+++ b/scripts/install_casperlabs_ee.sh
@@ -17,7 +17,7 @@ git fetch origin
 git reset --hard $COMMIT_HASH
 
 cd execution-engine
-make setup
+make setup-rs
 cargo build --release # build execution engine
 
 declare -a TARGET_CONTRACTS=(


### PR DESCRIPTION
Since we are currently not supporting AssemblyScript contract,
remove install dependency on node.