### PR TITLE
Replace from bech32 parameter into base64 in custom contract run

### DIFF
--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -644,6 +644,11 @@ func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simu
 		return false, err.Error()
 	}
 
+	replacedSessionArgs, err := ReplaceFromBech32ToHex(msg.SessionArgs)
+	if err != nil {
+		return false, err.Error()
+	}
+
 	executeAddress := []byte{}
 	if len(msg.ExecAddress) == sdk.AddrLen {
 		executeAddress = msg.ExecAddress
@@ -655,7 +660,7 @@ func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simu
 	deploys := []*ipc.DeployItem{}
 	deploy, err := util.MakeDeploy(
 		executeAddress,
-		msg.SessionType, msg.SessionCode, msg.SessionArgs,
+		msg.SessionType, msg.SessionCode, replacedSessionArgs,
 		util.HASH, proxyContractHash, paymentArgsJson,
 		types.BASIC_GAS, ctx.BlockTime().Unix(), ctx.ChainID())
 	if err != nil {

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -644,9 +644,15 @@ func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simu
 		return false, err.Error()
 	}
 
-	replacedSessionArgs, err := ReplaceFromBech32ToHex(isCustomContract, msg.SessionArgs)
+	replacedSessionArgs, addrList, err := ReplaceFromBech32ToHex(isCustomContract, msg.SessionArgs)
 	if err != nil {
 		return false, err.Error()
+	}
+
+	if isCustomContract {
+		for _, unitAddr := range addrList {
+			k.SetAccountIfNotExists(ctx, unitAddr)
+		}
 	}
 
 	executeAddress := []byte{}

--- a/x/executionlayer/handler.go
+++ b/x/executionlayer/handler.go
@@ -95,7 +95,7 @@ func handlerMsgTransfer(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgTr
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 	if result == true {
 		k.SetAccountIfNotExists(ctx, msg.ToAddress)
 	}
@@ -104,7 +104,7 @@ func handlerMsgTransfer(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgTr
 
 // Handle MsgExecute
 func handlerMsgExecute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simulate bool) sdk.Result {
-	result, log := execute(ctx, k, msg, simulate)
+	result, log := execute(ctx, k, msg, simulate, true)
 	return getResult(result, log)
 }
 
@@ -149,7 +149,7 @@ func handlerMsgCreateValidator(ctx sdk.Context, k ExecutionLayerKeeper, msg type
 			msg.Fee,
 		)
 
-		result, log := execute(ctx, k, msgExecute, simulate)
+		result, log := execute(ctx, k, msgExecute, simulate, false)
 
 		if parseError != nil {
 			return getResult(false, parseError.Error())
@@ -187,7 +187,7 @@ func handlerMsgEditValidator(ctx sdk.Context, k ExecutionLayerKeeper, msg types.
 		msg.Fee,
 	)
 
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	if !found {
 		return getResult(false, "validator does not exist for that address")
@@ -234,7 +234,7 @@ func handlerMsgBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgBond, 
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 	return getResult(result, log)
 }
 
@@ -273,7 +273,7 @@ func handlerMsgUnBond(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnBo
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -314,7 +314,7 @@ func handlerMsgDelegate(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgDe
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -358,7 +358,7 @@ func handlerMsgUndelgate(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgU
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -405,7 +405,7 @@ func handlerMsgRedelegate(ctx sdk.Context, k ExecutionLayerKeeper, msg types.Msg
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -483,7 +483,7 @@ func handlerMsgVote(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgVote, 
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -567,7 +567,7 @@ func handlerMsgUnvote(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgUnvo
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
@@ -605,12 +605,12 @@ func handlerMsgClaim(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgClaim
 		sessionArgsStr,
 		msg.Fee,
 	)
-	result, log := execute(ctx, k, msgExecute, simulate)
+	result, log := execute(ctx, k, msgExecute, simulate, false)
 
 	return getResult(result, log)
 }
 
-func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simulate bool) (bool, string) {
+func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simulate bool, isCustomContract bool) (bool, string) {
 	proxyContractHash := k.GetProxyContractHash(ctx)
 	// Parameter preparation
 	var stateHash []byte
@@ -644,7 +644,7 @@ func execute(ctx sdk.Context, k ExecutionLayerKeeper, msg types.MsgExecute, simu
 		return false, err.Error()
 	}
 
-	replacedSessionArgs, err := ReplaceFromBech32ToHex(msg.SessionArgs)
+	replacedSessionArgs, err := ReplaceFromBech32ToHex(isCustomContract, msg.SessionArgs)
 	if err != nil {
 		return false, err.Error()
 	}

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -90,7 +90,7 @@ func DeployArgsToJsonString(args []*consensus.Deploy_Arg) (string, error) {
 func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 	res := valueStr
 
-	r := regexp.MustCompile(`\"hash\":\{\"hash\":\"(fridaycontracthash[a-zA-Z0-9+/]+)\"`)
+	r := regexp.MustCompile(fmt.Sprintf(`\"hash\":\{\"hash\":\"(%s[a-zA-Z0-9+/]+)\"`, sdk.Bech32PrefixContractHash))
 	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
 		hashStr := matchedGroup[1]
 		hashaddr, err := sdk.ContractHashAddressFromBech32(hashStr)
@@ -104,7 +104,7 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		res = strings.Replace(res, filterHashStr, replaceStr, -1)
 	}
 
-	r = regexp.MustCompile(`\"uref\":\{\"uref\":\"(fridaycontracturef[a-zA-Z0-9+/]+)\"`)
+	r = regexp.MustCompile(fmt.Sprintf(`\"uref\":\{\"uref\":\"(%s[a-zA-Z0-9+/]+)\"`, sdk.Bech32PrefixContractURef))
 	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
 		urefStr := matchedGroup[1]
 		urefaddr, err := sdk.ContractUrefAddressFromBech32(urefStr)
@@ -118,7 +118,7 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		res = strings.Replace(res, filterUrefStr, replaceStr, -1)
 	}
 
-	r = regexp.MustCompile(`\"address\":\{\"account\":\"(friday[a-zA-Z0-9+/]+)\"`)
+	r = regexp.MustCompile(fmt.Sprintf(`{\"name\":\"address\",\"value\":{\"cl_type\":\{\"list\_type\":\{\"inner\":\{\"simple_type\":\"U8\"\}\}\},\"value\":\{\"bytes\_value\":\"(%s[a-zA-Z0-9+/]+)\"\}\}\}`, sdk.Bech32PrefixAccAddr))
 	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
 		accountStr := matchedGroup[1]
 		accountAddr, err := sdk.AccAddressFromBech32(accountStr)
@@ -127,8 +127,8 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		}
 		accountHex := base64.StdEncoding.EncodeToString(accountAddr.Bytes())
 
-		filterAccountStr := `"address":{"account":"` + accountStr
-		replaceStr := `"address":{"account":"` + accountHex
+		filterAccountStr := `{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"` + accountStr
+		replaceStr := `{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"` + accountHex
 		res = strings.Replace(res, filterAccountStr, replaceStr, -1)
 	}
 

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -1,6 +1,7 @@
 package executionlayer
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"regexp"
@@ -96,8 +97,11 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		if err != nil {
 			return valueStr, err
 		}
-		hashaddrhex := hex.EncodeToString(hashaddr.Bytes())
-		res = strings.Replace(res, hashStr, hashaddrhex, -1)
+		hashaddrhex := base64.StdEncoding.EncodeToString(hashaddr.Bytes())
+
+		filterHashStr := `"hash":{"hash":"` + hashStr
+		replaceStr := `"hash":{"hash":"` + hashaddrhex
+		res = strings.Replace(res, filterHashStr, replaceStr, -1)
 	}
 
 	r = regexp.MustCompile(`\"uref\":\{\"uref\":\"(fridaycontracturef[a-zA-Z0-9+/]+)\"`)
@@ -107,8 +111,11 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		if err != nil {
 			return valueStr, err
 		}
-		urefaddrhex := hex.EncodeToString(urefaddr.Bytes())
-		res = strings.Replace(res, urefStr, urefaddrhex, -1)
+		urefaddrhex := base64.StdEncoding.EncodeToString(urefaddr.Bytes())
+
+		filterUrefStr := `"uref":{"uref":"` + urefStr
+		replaceStr := `"uref":{"uref":"` + urefaddrhex
+		res = strings.Replace(res, filterUrefStr, replaceStr, -1)
 	}
 
 	r = regexp.MustCompile(`\"address\":\{\"account\":\"(friday[a-zA-Z0-9+/]+)\"`)
@@ -118,8 +125,11 @@ func ReplaceFromBech32ToHex(valueStr string) (string, error) {
 		if err != nil {
 			return valueStr, err
 		}
-		accountHex := hex.EncodeToString(accountAddr.Bytes())
-		res = strings.Replace(res, accountStr, accountHex, -1)
+		accountHex := base64.StdEncoding.EncodeToString(accountAddr.Bytes())
+
+		filterAccountStr := `"address":{"account":"` + accountStr
+		replaceStr := `"address":{"account":"` + accountHex
+		res = strings.Replace(res, filterAccountStr, replaceStr, -1)
 	}
 
 	return res, nil

--- a/x/executionlayer/util.go
+++ b/x/executionlayer/util.go
@@ -3,6 +3,8 @@ package executionlayer
 import (
 	"encoding/hex"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus"
@@ -82,4 +84,43 @@ func DeployArgsToJsonString(args []*consensus.Deploy_Arg) (string, error) {
 	str += "]"
 
 	return str, nil
+}
+
+func ReplaceFromBech32ToHex(valueStr string) (string, error) {
+	res := valueStr
+
+	r := regexp.MustCompile(`\"hash\":\{\"hash\":\"(fridaycontracthash[a-zA-Z0-9+/]+)\"`)
+	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
+		hashStr := matchedGroup[1]
+		hashaddr, err := sdk.ContractHashAddressFromBech32(hashStr)
+		if err != nil {
+			return valueStr, err
+		}
+		hashaddrhex := hex.EncodeToString(hashaddr.Bytes())
+		res = strings.Replace(res, hashStr, hashaddrhex, -1)
+	}
+
+	r = regexp.MustCompile(`\"uref\":\{\"uref\":\"(fridaycontracturef[a-zA-Z0-9+/]+)\"`)
+	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
+		urefStr := matchedGroup[1]
+		urefaddr, err := sdk.ContractUrefAddressFromBech32(urefStr)
+		if err != nil {
+			return valueStr, err
+		}
+		urefaddrhex := hex.EncodeToString(urefaddr.Bytes())
+		res = strings.Replace(res, urefStr, urefaddrhex, -1)
+	}
+
+	r = regexp.MustCompile(`\"address\":\{\"account\":\"(friday[a-zA-Z0-9+/]+)\"`)
+	for _, matchedGroup := range r.FindAllStringSubmatch(valueStr, -1) {
+		accountStr := matchedGroup[1]
+		accountAddr, err := sdk.AccAddressFromBech32(accountStr)
+		if err != nil {
+			return valueStr, err
+		}
+		accountHex := hex.EncodeToString(accountAddr.Bytes())
+		res = strings.Replace(res, accountStr, accountHex, -1)
+	}
+
+	return res, nil
 }

--- a/x/executionlayer/util_test.go
+++ b/x/executionlayer/util_test.go
@@ -1,0 +1,27 @@
+package executionlayer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceFromBech32ToHex(t *testing.T) {
+	testInput := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
+		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"fridaycontracthash1fh7vqy3zp945f0xel3h7x7sj6rq5hw509q2jmdsfndqh8ygcj4mqcgh9n7"}}}}},` +
+		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"fridaycontracturef1zqaevn0n0haygwq9dmqk0came8lmxqa6fp876pvsj54mm0pnycjssj50u9"}}}}},` +
+		`{"name":"my_address","value":{"clType":{"simpleType":"KEY"},"value":{"key":{"address":{"account":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}}},` +
+		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
+
+	res, _ := ReplaceFromBech32ToHex(testInput)
+	fmt.Println(res)
+
+	expectedRes := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
+		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"TfzAEiIJa0S82fxv43oS0MFLuo8oFS22CZtBc5EYlXY="}}}}},` +
+		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"EDuWTfN9+kQ4BW7BZ+O7yf+zA7pIT+0FkJUrvbwzJiU="}}}}},` +
+		`{"name":"my_address","value":{"clType":{"simpleType":"KEY"},"value":{"key":{"address":{"account":"tTRwYic89GpaB72d8igFHzIZwOMZYIASRrFwTXVAAdE="}}}}},` +
+		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
+
+	assert.Equal(t, res, expectedRes)
+}

--- a/x/executionlayer/util_test.go
+++ b/x/executionlayer/util_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	sdk "github.com/hdac-io/friday/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +15,7 @@ func TestReplaceFromBech32ToHex(t *testing.T) {
 		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}},` +
 		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
 
-	res, _ := ReplaceFromBech32ToHex(true, testInput)
+	res, addrList, _ := ReplaceFromBech32ToHex(true, testInput)
 	fmt.Println(res)
 
 	expectedRes := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
@@ -24,4 +25,7 @@ func TestReplaceFromBech32ToHex(t *testing.T) {
 		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
 
 	assert.Equal(t, res, expectedRes)
+
+	unitAddr, _ := sdk.AccAddressFromBech32("friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm")
+	assert.Equal(t, addrList, []sdk.AccAddress{unitAddr})
 }

--- a/x/executionlayer/util_test.go
+++ b/x/executionlayer/util_test.go
@@ -14,7 +14,7 @@ func TestReplaceFromBech32ToHex(t *testing.T) {
 		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}},` +
 		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
 
-	res, _ := ReplaceFromBech32ToHex(testInput)
+	res, _ := ReplaceFromBech32ToHex(true, testInput)
 	fmt.Println(res)
 
 	expectedRes := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +

--- a/x/executionlayer/util_test.go
+++ b/x/executionlayer/util_test.go
@@ -11,7 +11,7 @@ func TestReplaceFromBech32ToHex(t *testing.T) {
 	testInput := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
 		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"fridaycontracthash1fh7vqy3zp945f0xel3h7x7sj6rq5hw509q2jmdsfndqh8ygcj4mqcgh9n7"}}}}},` +
 		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"fridaycontracturef1zqaevn0n0haygwq9dmqk0came8lmxqa6fp876pvsj54mm0pnycjssj50u9"}}}}},` +
-		`{"name":"my_address","value":{"clType":{"simpleType":"KEY"},"value":{"key":{"address":{"account":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}}},` +
+		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}},` +
 		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
 
 	res, _ := ReplaceFromBech32ToHex(testInput)
@@ -20,7 +20,7 @@ func TestReplaceFromBech32ToHex(t *testing.T) {
 	expectedRes := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
 		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"TfzAEiIJa0S82fxv43oS0MFLuo8oFS22CZtBc5EYlXY="}}}}},` +
 		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"EDuWTfN9+kQ4BW7BZ+O7yf+zA7pIT+0FkJUrvbwzJiU="}}}}},` +
-		`{"name":"my_address","value":{"clType":{"simpleType":"KEY"},"value":{"key":{"address":{"account":"tTRwYic89GpaB72d8igFHzIZwOMZYIASRrFwTXVAAdE="}}}}},` +
+		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"tTRwYic89GpaB72d8igFHzIZwOMZYIASRrFwTXVAAdE="}}},` +
 		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
 
 	assert.Equal(t, res, expectedRes)


### PR DESCRIPTION
### Update
* User can use friday-prefixed address into JSON parameter

**As-is of input parameter**
No conversion into EE-understandable style. Developer should encode the parameter themselves when the type of the parameter is one of `PublicKey`, `URef`, `Hash`, and so on.

```go
`[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"TfzAEiIJa0S82fxv43oS0MFLuo8oFS22CZtBc5EYlXY="}}}}},` +
		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"EDuWTfN9+kQ4BW7BZ+O7yf+zA7pIT+0FkJUrvbwzJiU="}}}}},` +
		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"tTRwYic89GpaB72d8igFHzIZwOMZYIASRrFwTXVAAdE="}}},` +
		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
```

**To-be of input parameter**
Decode parameters at handler so that the dApp developer can use friday-prefixed parameter
**Plus** if the address parameter is in args, check the account existence and create the account if doesn't exist
```go
testInput := `[{"name":"method","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"set_swap_hash"}}},` +
		`{"name":"hash","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"hash":{"hash":"fridaycontracthash1fh7vqy3zp945f0xel3h7x7sj6rq5hw509q2jmdsfndqh8ygcj4mqcgh9n7"}}}}},` +
		`{"name":"uref","value":{"cl_type":{"simple_type":"KEY"},"value":{"key":{"uref":{"uref":"fridaycontracturef1zqaevn0n0haygwq9dmqk0came8lmxqa6fp876pvsj54mm0pnycjssj50u9"}}}}},` +
		`{"name":"address","value":{"cl_type":{"list_type":{"inner":{"simple_type":"U8"}}},"value":{"bytes_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}},` +
		`{"name":"address_as_string","value":{"cl_type":{"simple_type":"STRING"},"value":{"str_value":"friday1k568qc388n6x5ks8hkwly2q9ruepns8rr9sgqyjxk9cy6a2qq8gs4v2kpm"}}}]`
```


### Limitation in implementation
* Golang does not parse entire JSON. It can only unmarshal same hierarchy. (Even unmarshal as `map[string]interface{}`)
* Regex seems to be optimized implementation in this case