### PR TITLE
refactor: delete to unnecessary marshalling

### DIFF
--- a/integration_tests/test_single_node_simple_cli.py
+++ b/integration_tests/test_single_node_simple_cli.py
@@ -247,6 +247,8 @@ class TestSingleNode():
         # Reason: Just enough value to ensure that tx become invalid
         assert(self.basic_coin_amount / 3 < int(res_after))
 
+        time.sleep(self.tx_block_time * 3 + 1)
+
         print("Unbond and try to transfer")
         print("Unbond first")
         tx_hash_unbond, success = cmd.unbond(self.wallet_password, self.basic_coin_amount / 30, self.bonding_fee, self.wallet_anna)

--- a/types/block.go
+++ b/types/block.go
@@ -1,11 +1,13 @@
 package types
 
 import (
+	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/casper/consensus/state"
 	"github.com/hdac-io/casperlabs-ee-grpc-go-util/protobuf/io/casperlabs/ipc"
 )
 
 type CandidateBlock struct {
-	Hash  []byte      `json:"hash"`
-	State []byte      `json:"state"`
-	Bonds []*ipc.Bond `json:"bonds"`
+	Hash            []byte      `json:"hash"`
+	State           []byte      `json:"state"`
+	Bonds           []*ipc.Bond `json:"bonds"`
+	ProtocolVersion *state.ProtocolVersion
 }

--- a/types/block.go
+++ b/types/block.go
@@ -6,8 +6,8 @@ import (
 )
 
 type CandidateBlock struct {
-	Hash            []byte      `json:"hash"`
-	State           []byte      `json:"state"`
-	Bonds           []*ipc.Bond `json:"bonds"`
-	ProtocolVersion *state.ProtocolVersion
+	Hash            []byte                 `json:"hash"`
+	State           []byte                 `json:"state"`
+	Bonds           []*ipc.Bond            `json:"bonds"`
+	ProtocolVersion *state.ProtocolVersion `json:"protocol_version"`
 }

--- a/x/executionlayer/abci.go
+++ b/x/executionlayer/abci.go
@@ -18,17 +18,18 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, elk ExecutionLaye
 	candidateBlock := ctx.CandidateBlock()
 	candidateBlock.Hash = req.GetHash()
 	candidateBlock.State = unitHash.EEState
+	protocolVersion := elk.GetProtocolVersion(ctx)
+	candidateBlock.ProtocolVersion = &protocolVersion
 }
 
 func EndBlocker(ctx sdk.Context, req abci.RequestEndBlock, k ExecutionLayerKeeper) []abci.ValidatorUpdate {
 	var validatorUpdates []abci.ValidatorUpdate
 
 	// step
-	protocolVersion := k.MustGetProtocolVersion(ctx)
 	stepRequest := &ipc.StepRequest{
 		ParentStateHash: ctx.CandidateBlock().State,
 		BlockTime:       uint64(ctx.BlockTime().Unix()),
-		ProtocolVersion: &protocolVersion,
+		ProtocolVersion: ctx.CandidateBlock().ProtocolVersion,
 	}
 	res, err := k.client.Step(ctx.Context(), stepRequest)
 	if err != nil {

--- a/x/executionlayer/genesis.go
+++ b/x/executionlayer/genesis.go
@@ -101,6 +101,7 @@ func InitGenesis(
 	}
 
 	keeper.SetProxyContractHash(ctx, proxyContractHash)
+	keeper.SetProtocolVersion(ctx, *genesisConfig.ProtocolVersion)
 	keeper.SetUnitHashMap(ctx, types.NewUnitHashMap(ctx.CandidateBlock().State))
 
 	return validatorUpdates
@@ -111,7 +112,7 @@ func ExportGenesis(ctx sdk.Context, keeper ExecutionLayerKeeper) types.GenesisSt
 	existAccounts := keeper.AccountKeeper.GetAllAccounts(ctx)
 
 	stateHash := keeper.GetUnitHashMap(ctx, ctx.BlockHeight()).EEState
-	protocolVersion := keeper.MustGetProtocolVersion(ctx)
+	protocolVersion := keeper.GetProtocolVersion(ctx)
 
 	stakeAmounts := map[string]string{}
 	for _, validator := range validators {

--- a/x/executionlayer/keeper.go
+++ b/x/executionlayer/keeper.go
@@ -38,15 +38,6 @@ func NewExecutionLayerKeeper(
 	}
 }
 
-func (k ExecutionLayerKeeper) MustGetProtocolVersion(ctx sdk.Context) state.ProtocolVersion {
-	genesisConf := k.GetGenesisConf(ctx)
-	pv, err := types.ToProtocolVersion(genesisConf.Genesis.ProtocolVersion)
-	if err != nil {
-		panic(fmt.Errorf("System has invalid protocol version: %v", err))
-	}
-	return *pv
-}
-
 // -----------------------------------------------------------------------------------------------------------
 
 // SetUnitHashMap map unitHash to blockHash
@@ -223,4 +214,22 @@ func (k ExecutionLayerKeeper) GetProxyContractHash(ctx sdk.Context) []byte {
 func (k ExecutionLayerKeeper) SetProxyContractHash(ctx sdk.Context, contractHash []byte) {
 	store := ctx.KVStore(k.HashMapStoreKey)
 	store.Set([]byte(types.ProxyContractHashKey), contractHash)
+}
+
+// -----------------------------------------------------------------------------------------------------------
+// GetProtocolVersion retrieves protocol version
+func (k ExecutionLayerKeeper) GetProtocolVersion(ctx sdk.Context) state.ProtocolVersion {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	protocolVersionBytes := store.Get([]byte(types.ProtoclVersionKey))
+	var protocolVersion state.ProtocolVersion
+	k.cdc.UnmarshalBinaryBare(protocolVersionBytes, &protocolVersion)
+
+	return protocolVersion
+}
+
+// SetProtocolVersion save protocol version.
+func (k ExecutionLayerKeeper) SetProtocolVersion(ctx sdk.Context, protocolVersion state.ProtocolVersion) {
+	store := ctx.KVStore(k.HashMapStoreKey)
+	protocolVersionBytes := k.cdc.MustMarshalBinaryBare(protocolVersion)
+	store.Set([]byte(types.ProtoclVersionKey), protocolVersionBytes)
 }

--- a/x/executionlayer/keeper_test.go
+++ b/x/executionlayer/keeper_test.go
@@ -65,23 +65,6 @@ func TestUnitHashMapInCorrectInput(t *testing.T) {
 	unitHash := input.elk.GetUnitHashMap(input.ctx, input.ctx.BlockHeight())
 	assert.NotEqual(t, eeState, unitHash.EEState)
 }
-
-func TestMustGetProtocolVersion(t *testing.T) {
-	expected, err := types.ToProtocolVersion(types.DefaultGenesisState().GenesisConf.Genesis.ProtocolVersion)
-	assert.Nil(t, err)
-
-	input := setupTestInput()
-	got := input.elk.MustGetProtocolVersion(input.ctx)
-	assert.Equal(t, *expected, got)
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("MustGetProtocolVersion below should panic!")
-		}
-	}()
-	input.elk.MustGetProtocolVersion(sdk.Context{})
-}
-
 func TestMarsahlAndUnMarshal(t *testing.T) {
 	src := &transforms.TransformEntry{
 		Transform: &transforms.Transform{TransformInstance: &transforms.Transform_Write{Write: &transforms.TransformWrite{Value: &state.StoredValue{Variants: &state.StoredValue_ClValue{ClValue: &state.CLValue{ClType: &state.CLType{Variants: &state.CLType_SimpleType{SimpleType: state.CLType_BOOL}}, SerializedValue: []byte{1, 2, 3}}}}}}}}
@@ -169,4 +152,15 @@ func TestProxyContractKeeper(t *testing.T) {
 	res := input.elk.GetProxyContractHash(input.ctx)
 
 	assert.Equal(t, contractHash, res)
+}
+
+func TestProtocolVersionKeeper(t *testing.T) {
+	input := setupTestInput()
+
+	src := state.ProtocolVersion{Major: 1, Minor: 2, Patch: 3}
+
+	input.elk.SetProtocolVersion(input.ctx, src)
+	res := input.elk.GetProtocolVersion(input.ctx)
+
+	assert.Equal(t, src, res)
 }

--- a/x/executionlayer/querier.go
+++ b/x/executionlayer/querier.go
@@ -98,7 +98,7 @@ func queryBalanceDetail(ctx sdk.Context, path []string, req abci.RequestQuery, k
 	}
 
 	eeState := keeper.GetUnitHashMap(ctx, req.GetHeight()).EEState
-	protocolVersion := keeper.MustGetProtocolVersion(ctx)
+	protocolVersion := keeper.GetProtocolVersion(ctx)
 	val, errMsg := grpc.QueryBalance(keeper.client, eeState, param.Address, &protocolVersion)
 	if errMsg != "" {
 		return nil, sdk.NewError(sdk.CodespaceUndefined, sdk.CodeUnknownRequest, "Bad request: {}", errMsg)
@@ -174,7 +174,7 @@ func getQueryResult(ctx sdk.Context, k ExecutionLayerKeeper,
 		arrPath = strings.Split(path, "/")
 	}
 
-	protocolVersion := k.MustGetProtocolVersion(ctx)
+	protocolVersion := k.GetProtocolVersion(ctx)
 	stateHash := k.GetUnitHashMap(ctx, ctx.BlockHeight()).EEState
 	if len(stateHash) == 0 {
 		stateHash = ctx.CandidateBlock().State

--- a/x/executionlayer/test_common.go
+++ b/x/executionlayer/test_common.go
@@ -166,7 +166,7 @@ func counterDefine(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 		panic(err)
 	}
 	cntDefCode := util.LoadWasmFile(path.Join(contractPath, counterDefineWasm))
-	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
+	protocolVersion := input.elk.GetProtocolVersion(input.ctx)
 	genesisAddr := input.elk.GetGenesisAccounts(input.ctx)[0]
 
 	deploy, err := util.MakeDeploy(genesisAddr.Address, util.WASM, cntDefCode, "",
@@ -215,7 +215,7 @@ func counterCall(keeper ExecutionLayerKeeper, parentStateHash []byte) []byte {
 		panic(err)
 	}
 	cntCallCode := util.LoadWasmFile(path.Join(contractPath, counterCallWasm))
-	protocolVersion := input.elk.MustGetProtocolVersion(input.ctx)
+	protocolVersion := input.elk.GetProtocolVersion(input.ctx)
 	genesisAddr := input.elk.GetGenesisAccounts(input.ctx)[0]
 
 	timestamp = time.Now().Unix()

--- a/x/executionlayer/types/key.go
+++ b/x/executionlayer/types/key.go
@@ -20,6 +20,7 @@ const (
 	GenesisAccountKey    = "genesisaccount"
 	CandidateBlockKey    = "candidateblock"
 	ProxyContractHashKey = "proxycontractkey"
+	ProtoclVersionKey    = "protocolversion"
 )
 
 var (


### PR DESCRIPTION
 - using new key in protocol version
- protocol version only call in begin block