### PR TITLE
fix: change max tx bytes to 5MiB for swap contract

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -94,7 +94,7 @@ func interceptLoadConfig() (conf *cfg.Config, err error) {
 		conf.TxIndex.IndexAllTags = true
 		conf.Consensus.TimeoutCommit = 5 * time.Second
 		// set max body and yx bytes to 3MiB
-		maxBytes := 3 * 1024 * 1024 // 3MiB
+		maxBytes := 5 * 1024 * 1024 // 5MiB
 		conf.RPC.MaxBodyBytes = int64(maxBytes)
 		conf.Mempool.MaxTxBytes = maxBytes
 		cfg.WriteConfigFile(configFilePath, conf)


### PR DESCRIPTION
`swap` WASM takes 3.x MiB.
I raised the capacity enough, to 5 MiB