### PR TITLE
Changed JSON descriptor of balance & stake querying

### DIFF
--- a/x/executionlayer/client/rest/msgCreator.go
+++ b/x/executionlayer/client/rest/msgCreator.go
@@ -572,9 +572,6 @@ func getStakeQuerying(w http.ResponseWriter, cliCtx context.CLIContext, r *http.
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	queryData := types.QueryGetStakeDetail{
 		Address: addr,
 	}

--- a/x/executionlayer/types/query.go
+++ b/x/executionlayer/types/query.go
@@ -29,7 +29,7 @@ func (q QueryExecutionLayerDetail) String() string {
 
 // QueryGetBalanceDetail payload for balance query
 type QueryGetBalanceDetail struct {
-	Address sdk.AccAddress `json:"address"`
+	Address sdk.AccAddress `json:"address_holder"`
 }
 
 // implement fmt.Stringer
@@ -39,7 +39,7 @@ func (q QueryGetBalanceDetail) String() string {
 
 // QueryGetStakeDetail payload for stake query
 type QueryGetStakeDetail struct {
-	Address sdk.AccAddress `json:"address"`
+	Address sdk.AccAddress `json:"address_staker"`
 }
 
 // implement fmt.Stringer


### PR DESCRIPTION
### As-is
* Struct of `get balance` and `get stake` are same
* In REST call, unmarshaled JSON changed into balance query only

### To-be
* Modified JSON descriptor
* Avoid type confusing

Tested at https://travis-ci.org/github/psy2848048/hdacpy , `test02_rest_bond_and_unbond`
Currently marked as fail but it is rounding issue