### PR TITLE
apply systemd service

### DIFF
--- a/systemd_service/execution-engine.service
+++ b/systemd_service/execution-engine.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Execution Engine for Friday Platform
+After=network-online.target
+
+[Service]
+User=ubuntu
+ExecStart=/home/ubuntu/friday/CasperLabs/execution-engine/target/release/casperlabs-engine-grpc-server -t 8 /home/ubuntu/.casperlabs/.casper-node.sock -z
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd_service/nodef.service
+++ b/systemd_service/nodef.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Node for Friday Platform
+After=execution-engine.service
+BindTo=execution-engine.service
+
+[Service]
+User=ubuntu
+#ExecStartPre=/bin/sleep 3
+ExecStartPre=/usr/bin/test ! -f /home/ubuntu/.casperlabs/.casper-node.sock
+ExecStart=/home/ubuntu/go/bin/nodef start
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- usage
systemctl enable execution-engine.service
systemctl enable nodef.service

- note
If you start nodef.service, then execution-engine.service will start together.
If you restart / stop execution-engine service, then nodef.service will restart / stop together.
If you restart / stop nodef.service, execution-engine.service doesn't matter.

Signed-off-by: yoosah <yoosah@gmail.com>